### PR TITLE
Group ESLint dependencies in Dependabot to prevent conflicts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,10 +22,25 @@ updates:
     labels:
       - "dependencies"
       - "javascript"
-    # Group development dependencies together
+    # Group related dependencies together
     groups:
+      # Group ESLint and TypeScript ESLint dependencies to avoid peer dependency conflicts
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@typescript-eslint/*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+      # Group other development dependencies together
       dev-dependencies:
         dependency-type: "development"
+        exclude-patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@typescript-eslint/*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
ESLint and TypeScript ESLint packages have strict peer dependency requirements that cause conflicts when updated independently. This creates a dedicated group for eslint* and @typescript-eslint/* packages to ensure they are updated together in a single PR, preventing peer dependency mismatches and CI failures.