### PR TITLE
Add TypeScript to Dependabot ESLint grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,25 +22,25 @@ updates:
     labels:
       - "dependencies"
       - "javascript"
-    # Group related dependencies together
     groups:
-      # Group ESLint and TypeScript ESLint dependencies to avoid peer dependency conflicts
+      # Group ESLint, TypeScript, and TypeScript ESLint dependencies to avoid peer dependency conflicts
       eslint:
         patterns:
           - "eslint"
           - "eslint-*"
           - "@typescript-eslint/*"
+          - "typescript"
         update-types:
           - "major"
           - "minor"
           - "patch"
-      # Group other development dependencies together
       dev-dependencies:
         dependency-type: "development"
         exclude-patterns:
           - "eslint"
           - "eslint-*"
           - "@typescript-eslint/*"
+          - "typescript"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
Fixes peer dependency conflicts between TypeScript and @typescript-eslint packages that occur when Dependabot updates them independently. This resolves the build failure in PR #25 where TypeScript 5.9.2 was incompatible with @typescript-eslint/eslint-plugin@8.38.0.

By grouping these packages together, Dependabot will update the entire TypeScript ecosystem as a cohesive unit, ensuring version compatibility and preventing future CI failures due to peer dependency mismatches.

Also removes redundant comments from the configuration file for clarity.