### PR TITLE
Add chalk mock and update Jest config for test compatibility

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -106,6 +106,38 @@ module.exports = [
     },
   },
 
+  // JavaScript configuration for test files
+  {
+    files: ["test/**/*.js"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "commonjs",
+      globals: {
+        ...commonNodeGlobals,
+        // Jest globals
+        describe: "readonly",
+        it: "readonly",
+        expect: "readonly",
+        beforeEach: "readonly",
+        afterEach: "readonly",
+        beforeAll: "readonly",
+        afterAll: "readonly",
+        jest: "readonly",
+      },
+    },
+    rules: {
+      quotes: ["error", "double", { avoidEscape: true }],
+      semi: ["error", "always"],
+      "no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
+
   // TypeScript configuration for test files
   {
     files: ["test/**/*.ts"],

--- a/jest.config.json
+++ b/jest.config.json
@@ -26,5 +26,9 @@
         "tsconfig": "tsconfig.test.json"
       }
     ]
+  },
+  "transformIgnorePatterns": ["/node_modules/"],
+  "moduleNameMapper": {
+    "^chalk$": "<rootDir>/test/mocks/chalk.js"
   }
 }

--- a/test/mocks/chalk.js
+++ b/test/mocks/chalk.js
@@ -1,0 +1,60 @@
+// Mock implementation of chalk for Jest tests
+const chalk = {
+  // Basic colors
+  red: (text) => text,
+  green: (text) => text,
+  blue: (text) => text,
+  yellow: (text) => text,
+  cyan: (text) => text,
+  magenta: (text) => text,
+  white: (text) => text,
+  black: (text) => text,
+  gray: (text) => text,
+  grey: (text) => text,
+
+  // Bright colors
+  redBright: (text) => text,
+  greenBright: (text) => text,
+  blueBright: (text) => text,
+  yellowBright: (text) => text,
+  cyanBright: (text) => text,
+  magentaBright: (text) => text,
+  whiteBright: (text) => text,
+  blackBright: (text) => text,
+
+  // Background colors
+  bgRed: (text) => text,
+  bgGreen: (text) => text,
+  bgBlue: (text) => text,
+  bgYellow: (text) => text,
+  bgCyan: (text) => text,
+  bgMagenta: (text) => text,
+  bgWhite: (text) => text,
+  bgBlack: (text) => text,
+
+  // Styles
+  bold: (text) => text,
+  dim: (text) => text,
+  italic: (text) => text,
+  underline: (text) => text,
+  inverse: (text) => text,
+  strikethrough: (text) => text,
+
+  // Allow chaining
+  __proto__: new Proxy(
+    {},
+    {
+      get: () => (text) => text,
+    },
+  ),
+};
+
+// Make chalk chainable
+Object.keys(chalk).forEach((key) => {
+  if (typeof chalk[key] === "function") {
+    Object.setPrototypeOf(chalk[key], chalk);
+  }
+});
+
+module.exports = chalk;
+module.exports.default = chalk;


### PR DESCRIPTION
The chalk library changed its module format in recent versions, causing Jest tests to fail with ESM/CommonJS compatibility issues. This change adds a comprehensive chalk mock that provides all the styling functions as pass-through implementations for testing purposes.

Changes:
- Add chalk mock in test/mocks/chalk.js with full API coverage
- Update Jest config to map chalk imports to the mock
- Add ESLint configuration for JavaScript test files

This ensures tests continue to pass without depending on chalk's module format while maintaining test coverage of chalk-dependent code.