### PR TITLE
chore(actions): harden workflow defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,18 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
     name: Test
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -51,6 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     name: Build
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -80,6 +89,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     name: Performance Benchmarks
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -12,12 +12,17 @@ on:
       - ".github/workflows/deps.yml"
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   unused:
     name: Check unused
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -38,6 +43,9 @@ jobs:
   sync-precommit:
     name: Sync pre-commit dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
     if: >
       github.event_name == 'pull_request' &&
       !contains(github.event.head_commit.author.name, 'woodland-generators[bot]')

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -14,9 +14,17 @@ on:
       - ".github/workflows/environment.yml"
       - "scripts/validate-workspace.ts"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   validate-environment:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -9,9 +9,17 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   lychee:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,12 +5,19 @@ on:
     - cron: "0 0 * * *" # Run daily at midnight UTC
 
 permissions:
-  issues: write
-  pull-requests: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   stale:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v9
         with:


### PR DESCRIPTION
## Summary

All five workflows now declare `permissions: contents: read`,
`timeout-minutes`, and a `concurrency` group, matching the hygiene
already applied in the genshin and chezmoi projects. PR runs cancel
superseded jobs while master commits finish; jobs no longer inherit
the repository's permissive token scope or run unbounded.

## Gotchas

- `bench` (ci.yml) keeps `contents: write` + `pull-requests: write`
  so `github-action-benchmark` can post alert comments on commits
  (push events) and PRs.
- `sync-precommit` (deps.yml) keeps `contents: write` for its
  pre-commit autofix push; the comment in the issue noted this stays
  until the Renovate migration retires the job.
- `stale.yml` moves `issues:write` + `pull-requests:write` from
  workflow scope to the job, with `contents: read` at workflow scope.

## Verification

- `npx prettier --check .github/workflows/*.yml` — passes.
- Pre-commit hooks ran on commit (prettier, end-of-file-fixer, etc.)
  — all passed.

Closes #119