### PR TITLE
docs: backfill CHANGELOG with demeanor and details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project appear in this file.
 
-The format follows [Keep a CHANGELOG](https://keepachangelog.com/en/1.0.0/), and
+The format follows [Keep a CHANGELOG](https://keepachangelog.com/en/1.1.0/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
@@ -19,6 +19,8 @@ this project adheres to
   - Name generation for woodland creatures
   - Background, feat, and move generation
   - Playbook-specific archetype selection
+  - Character details generation (pronouns, appearance, accessories)
+  - Demeanor traits drawn from playbook personality options
 - Reproducible character generation via `--seed` option
 - Custom name override via `--name` option
 - Specific archetype selection via `--archetype` option


### PR DESCRIPTION
## Summary

`[Unreleased]` now reflects the user-visible character generation
work that landed since the last CHANGELOG edit: demeanor traits
(PR #48) and character details — pronouns, appearance, accessories
(PR #41). Both were merged without touching the changelog, so the
v0.2.0 release notes would have shipped without them.

Internal work since that point — codecov plumbing, benchmark CI,
the stats→maths rename, eslint/jest/chalk dependency churn, and
the Renovate migration — is intentionally omitted per the issue's
user-visible scope.

Also bumps the Keep a CHANGELOG header link from 1.0.0 to 1.1.0 to
match the format the issue calls out.

Closes #124

## Gotchas

The new bullets sit *inside* the existing "Comprehensive character
generation from playbook PDF files including:" sub-list rather than
at the top level, since they're additional aspects of character
generation, not standalone features. Reviewer should sanity-check
that grouping reads correctly to a release-notes consumer.

Demeanor and details are exposed through the JSON character output
only — neither has a CLI flag yet, so the wording avoids implying
one. Worth confirming the entries don't promise more than the code
delivers.