### PR TITLE
Fix logger.debug arg order in JSONPlaybookSource.isValid

### DIFF
--- a/src/playbook/sources/json.ts
+++ b/src/playbook/sources/json.ts
@@ -68,7 +68,8 @@ export class JSONPlaybookSource extends PlaybookSource {
         validationDetails = `unsupported data type: ${typeof jsonData}`;
       }
 
-      this.logger.debug(isValidData ? "JSON validation successful" : "JSON validation failed", {
+      this.logger.debug({
+        msg: isValidData ? "JSON validation successful" : "JSON validation failed",
         path: this.path,
         validationDetails,
         isValid: isValidData,

--- a/src/playbook/sources/json.ts
+++ b/src/playbook/sources/json.ts
@@ -69,7 +69,7 @@ export class JSONPlaybookSource extends PlaybookSource {
       }
 
       this.logger.debug({
-        msg: isValidData ? "JSON validation successful" : "JSON validation failed",
+        msg: "JSON validation complete",
         path: this.path,
         validationDetails,
         isValid: isValidData,


### PR DESCRIPTION
## Summary

`logger.debug` call in `JSONPlaybookSource.isValid` now compiles under the bumped pino types and reports outcome via the structured `isValid` field. Pino has always wanted `(obj, msg)`; the call passed `(msg, obj)`, which compiled under 9.7.0 but breaks under 9.14.0 (the version Renovate's lockfile-maintenance PR #162 pulls in). Reordered to the `{msg, ...}` form already used everywhere else in this file, and dropped the conditional message string — the object already carries `isValid: isValidData`, so a fixed message expresses the same thing without a branch.

## Verification

- `npm run check:types` / `check:lint` / `check:format` — clean
- `npx tsc` against `pino@9.14.0` (the version #162 bumps to) — clean

Local `npm test` is broken on master too (unrelated `jest-util` hoisting in this sandbox), so test verification is left to CI.