### PR TITLE
Separate npm major updates and drop @types/chalk stub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
       },
       "devDependencies": {
         "@eslint/js": "9.39.4",
-        "@types/chalk": "0.4.31",
         "@types/jest": "29.5.14",
         "@types/node": "24.12.2",
         "@types/pdf-parse": "1.1.5",
@@ -1859,13 +1858,6 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
-    },
-    "node_modules/@types/chalk": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz",
-      "integrity": "sha512-nF0fisEPYMIyfrFgabFimsz9Lnuu9MwkNrrlATm2E4E46afKDyeelT+8bXfw1VSc7sLBxMxRgT7PxTC2JcqN4Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "devDependencies": {
     "@eslint/js": "9.39.4",
-    "@types/chalk": "0.4.31",
     "@types/jest": "29.5.14",
     "@types/node": "24.12.2",
     "@types/pdf-parse": "1.1.5",

--- a/renovate.json
+++ b/renovate.json
@@ -15,10 +15,17 @@
   },
   "packageRules": [
     {
-      "description": "Group all npm dependencies in a single PR",
+      "description": "Group non-major npm updates in a single PR; majors land individually for review",
       "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "npm dependencies",
       "groupSlug": "npm",
+      "addLabels": ["npm"]
+    },
+    {
+      "description": "Label major npm updates so they are easy to spot",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["major"],
       "addLabels": ["npm"]
     },
     {


### PR DESCRIPTION
## Summary

Renovate's `npm dependencies` group currently bundles every npm
update — major included — into one PR. The next major batch (#159)
shipped 10 majors at once, with a peer-dep conflict (`jest-bench`
still pins `jest@^29.7.0`) that left the lockfile unmergeable. One
blocked bump kept all the unrelated upgrades behind it.

This change scopes the group to non-major updates so majors land
individually for review, which is the `config:best-practices` default
intent. A second rule keeps the `npm` label on major PRs.

Also drops `@types/chalk`: it is a deprecated stub package — `npm
view @types/chalk deprecated` returns "chalk provides its own type
definitions, so you do not need this installed", and chalk has
shipped its own types since v2.

## Gotchas

After this lands, close #159. Renovate will respin the npm majors as
individual PRs on its next Friday run, and each can be reviewed
against its own breaking-change profile (chalk 5 ESM, jest-bench
upstream gap, pdf-parse v2 API change, etc.).

## Verification

- `npm run check:all` — types, lint, format, depcheck, 166 tests
  passing.
- `git diff origin/master -- package.json renovate.json` confirms
  the only intentional changes are the `@types/chalk` removal and
  the two-rule split for npm matching.