### PR TITLE
ci: trust codecov for coverage signal

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,33 +2,10 @@ coverage:
   status:
     project:
       default:
-        target: 50%
-        threshold: 5%
-        if_not_found: success
-      generators:
-        target: 70%
-        threshold: 3%
-        paths:
-          - src/generators/
-        if_not_found: success
+        threshold: 1%
     patch:
       default:
-        target: 60%
-        threshold: 5%
-        if_not_found: success
-
-flags:
-  unittests:
-    paths:
-      - src/
-    carryforward: false
-
-comment:
-  layout: "header,diff,flags,components,tree,footer"
-  behavior: default
-  require_changes: false
-  require_base: no
-  require_head: yes
+        threshold: 1%
 
 ignore:
   - "dist/"
@@ -42,6 +19,3 @@ ignore:
   - "**/*.bench.ts"
   - "src/cli.ts"
   - "src/logging/pino-pretty-transport.js"
-
-github_checks:
-  annotations: true

--- a/jest.config.json
+++ b/jest.config.json
@@ -3,6 +3,14 @@
   "testEnvironment": "node",
   "clearMocks": true,
   "collectCoverageFrom": ["src/**/*.ts", "!src/**/*.d.ts", "!src/cli.ts"],
+  "coverageThreshold": {
+    "global": {
+      "lines": 75,
+      "branches": 56,
+      "functions": 76,
+      "statements": 74
+    }
+  },
   "testPathIgnorePatterns": ["/node_modules/", "/dist/", ".*\\.bench\\.ts$"],
   "coverageReporters": ["text", "lcov", "html"],
   "reporters": [

--- a/jest.config.json
+++ b/jest.config.json
@@ -3,14 +3,6 @@
   "testEnvironment": "node",
   "clearMocks": true,
   "collectCoverageFrom": ["src/**/*.ts", "!src/**/*.d.ts", "!src/cli.ts"],
-  "coverageThreshold": {
-    "global": {
-      "lines": 75,
-      "branches": 56,
-      "functions": 76,
-      "statements": 74
-    }
-  },
   "testPathIgnorePatterns": ["/node_modules/", "/dist/", ".*\\.bench\\.ts$"],
   "coverageReporters": ["text", "lcov", "html"],
   "reporters": [


### PR DESCRIPTION
## Summary

Coverage regressions now fail PR checks. Codecov's project status fires when a PR drops project coverage by >1pp from base; patch status fires when patch coverage is >1pp below base project coverage. Replaces the previous `codecov.yml` settings, where the `target: 50%` floor was unreachable (current ~70%) and effectively decorative.

## Gotchas

- Not using Jest's `coverageThreshold`. A static absolute floor creates Goodhart pressure (write tests to bump the number) without adding much over codecov's relative gates. Codecov's `auto` target ratchets with the project as tests improve, no manual bumps.
- `threshold: 1%` was calibrated from real history. Pulled 55 commits of master from the codecov API: routine wobble is well under 1pp; the worst observed regression was −1.43pp, which 1% catches. `0%` (codecov's default) would flag routine ±0.5pp drift; `2%` would let the −1.43 regression through.
- `codecov.yml` collapsed from 47 lines to 21. Everything dropped was either restating a documented default (`if_not_found: success`, `comment.behavior`, `github_checks.annotations`, `flags.unittests.carryforward`) or marginal scope (per-subtree `generators` status check, custom comment layout, redundant flag paths). The `ignore` list stays — it's correctness, not customization, since codecov can't auto-detect what's source vs. built artifact in this repo.

## Verification

- Ran `npm run test:coverage` locally — passes. (No threshold gating in jest now; the pass condition is just "tests run and produce lcov.")
- Coverage history pulled from `https://api.codecov.io/api/v2/github/alunduil/repos/woodland-generators/commits/?branch=master` to ground the 1% threshold choice.

Closes #126