### PR TITLE
refactor(pdf): normalize whitespace before anchor matching

### DIFF
--- a/src/playbook/sources/debug.ts
+++ b/src/playbook/sources/debug.ts
@@ -24,6 +24,27 @@ export function normalizeWhitespace(text: string): string {
 }
 
 /**
+ * Normalize text for anchor matching while preserving line structure.
+ *
+ * PDF extractors deliver typographic punctuation (smart quotes, en/em dashes,
+ * ellipses), non-breaking spaces, and irregular runs of horizontal whitespace.
+ * Heading anchors like "Choose Your Nature" or "Where do you call home?" must
+ * survive all of those without bespoke per-anchor regexes. Newlines are kept
+ * because the splitter and several field parsers anchor on line boundaries.
+ */
+export function normalizeForMatching(text: string): string {
+  return text
+    .replace(/\r\n?/g, "\n")
+    .replace(/[‘’‚‛]/g, "'")
+    .replace(/[“”„‟]/g, '"')
+    .replace(/[–—―]/g, "-")
+    .replace(/…/g, "...")
+    .replace(/[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g, " ")
+    .replace(/[ \t]+/g, " ")
+    .replace(/[ \t]*\n[ \t]*/g, "\n");
+}
+
+/**
  * Create a debug-friendly text preview showing start and end of content
  * For short text, returns the full content. For long text, returns first and last
  * portions separated by "..." with total grapheme count of (sampleSize * 2 + 3).

--- a/src/playbook/sources/pdf.ts
+++ b/src/playbook/sources/pdf.ts
@@ -2,7 +2,12 @@ import { readFileSync } from "fs";
 import { extractText, getDocumentProxy } from "unpdf";
 import { Playbook } from "../types";
 import { PlaybookSource } from "./types";
-import { createTextPreview, createPositionHighlight, normalizeWhitespace } from "./debug";
+import {
+  createTextPreview,
+  createPositionHighlight,
+  normalizeForMatching,
+  normalizeWhitespace,
+} from "./debug";
 import { asPdfParseError, PdfParseError } from "./errors";
 import { summary } from "../../maths";
 
@@ -166,7 +171,7 @@ export class PDFPlaybookSource extends PlaybookSource {
     const splitPages: number[] = [0];
 
     for (let i = 0; i < pages.length; i++) {
-      const page = pages[i] ?? "";
+      const page = normalizeForMatching(pages[i] ?? "");
       const startsPlaybook = page
         .split("\n")
         .some((line) => line.trim().startsWith("Choose Your Nature"));
@@ -197,7 +202,7 @@ export class PDFPlaybookSource extends PlaybookSource {
     for (let i = 0; i < splitPages.length; i++) {
       const startPage = splitPages[i]!;
       const endPage = i + 1 < splitPages.length ? splitPages[i + 1]! : pages.length;
-      const section = pages.slice(startPage, endPage).join("\n").trim();
+      const section = normalizeForMatching(pages.slice(startPage, endPage).join("\n")).trim();
       if (section.length > minLength) {
         sections.push(section);
         this.logger.trace({
@@ -302,21 +307,23 @@ export class PDFPlaybookSource extends PlaybookSource {
    */
   private extractArchetype(text: string, sectionIndex: number): string {
     const archetypePatterns = [
-      // Look for "The [Name]" pattern at the beginning of sections (preserve "The")
+      // Letter classes use Unicode property escapes so non-ASCII archetype
+      // names (e.g. "The Nâgualisz") match. The ASCII-only [A-Z][a-z]+ form
+      // stopped at the first diacritic and fell through to "Unknown".
       {
-        regex: /^[^\w]*(The\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)/m,
+        regex: /^[^\p{L}\p{N}]*(The\s+\p{Lu}\p{Ll}+(?:\s+\p{Lu}\p{Ll}+)*)/mu,
         description: "The [Name] at section start",
       },
-      // Look for patterns near "Choose Your Nature" (preserve "The")
       {
-        regex: /(The\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)[^\w]*Choose Your Nature/i,
+        regex: /(The\s+\p{Lu}\p{Ll}+(?:\s+\p{Lu}\p{Ll}+)*)[^\p{L}\p{N}]*Choose Your Nature/iu,
         description: "The [Name] near Choose Your Nature",
       },
-      // Look for title-style headers (all caps or title case)
-      { regex: /^[^\w]*([A-Z][A-Z\s]+[A-Z])\s*$/m, description: "ALL CAPS title header" },
-      // Fallback: single word archetype names
       {
-        regex: /^[^\w]*([A-Z][a-z]+)[^\w]*Choose Your Nature/i,
+        regex: /^[^\p{L}\p{N}]*(\p{Lu}[\p{Lu}\s]+\p{Lu})\s*$/mu,
+        description: "ALL CAPS title header",
+      },
+      {
+        regex: /^[^\p{L}\p{N}]*(\p{Lu}\p{Ll}+)[^\p{L}\p{N}]*Choose Your Nature/iu,
         description: "Single word before Choose Your Nature",
       },
     ];

--- a/test/playbook/sources/debug.test.ts
+++ b/test/playbook/sources/debug.test.ts
@@ -2,8 +2,30 @@
  * Unit tests for debug utility functions - Edge cases and error conditions
  */
 
-import { createPositionHighlight } from "../../../src/playbook/sources/debug";
+import { createPositionHighlight, normalizeForMatching } from "../../../src/playbook/sources/debug";
 import { root } from "../../../src/logging";
+
+describe("normalizeForMatching", () => {
+  it("collapses non-breaking and other irregular spaces to a single space", () => {
+    // U+00A0 NBSP, U+2009 thin space, U+202F narrow NBSP — all collapse so that
+    // anchor strings ("Choose Your Nature") match regardless of the PDF
+    // extractor's whitespace choices.
+    const input = "Choose Your Nature here";
+    expect(normalizeForMatching(input)).toBe("Choose Your Nature here");
+  });
+
+  it("normalizes typographic punctuation to ASCII", () => {
+    expect(normalizeForMatching("“Hi” — it’s fine…")).toBe('"Hi" - it\'s fine...');
+  });
+
+  it("preserves newlines so line-anchored regexes still match", () => {
+    expect(normalizeForMatching("a   \n   b")).toBe("a\nb");
+  });
+
+  it("normalizes CRLF to LF", () => {
+    expect(normalizeForMatching("a\r\nb\rc")).toBe("a\nb\nc");
+  });
+});
 
 describe("createPositionHighlight", () => {
   let warnSpy: jest.SpyInstance;

--- a/test/playbook/sources/pdf.edge-cases.test.ts
+++ b/test/playbook/sources/pdf.edge-cases.test.ts
@@ -57,16 +57,14 @@ describe("PDFPlaybookSource - edge cases (issue #128)", () => {
     expect(pb!.archetype).toBe("The Ronin");
   });
 
-  it("non-ASCII archetype: regex misses the name and falls through to 'Unknown'", async () => {
-    // The fixture's archetype is "The Nâgualisz". The four extraction
-    // regexes use [A-Z][a-z]+ which is ASCII-only, so the "â" stops the
-    // match at "N" — too short for the 3<length<50 sanity check. The
-    // section is kept (playbook indicators present) but archetype is
-    // "Unknown".
+  it("non-ASCII archetype: Unicode-aware patterns capture diacritics", async () => {
+    // The fixture's archetype is "The Nâgualisz". The extraction patterns now
+    // use \p{Lu}\p{Ll}+ instead of [A-Z][a-z]+, so the "â" no longer truncates
+    // the match.
     const source = new PDFPlaybookSource(path.join(validDir, "non-ascii-archetype-1.pdf"), "pdf");
     await source.load();
     const [pb] = source.getPlaybooks();
     expect(source.getPlaybooks().length).toBe(1);
-    expect(pb!.archetype).toBe("Unknown");
+    expect(pb!.archetype).toBe("The Nâgualisz");
   });
 });


### PR DESCRIPTION
## Summary

Heading anchors (\"Choose Your Nature\", \"Where do you call home?\", section names) and the archetype extractor now run against a normalized form of each section, so PDF-extractor whitespace quirks no longer silently empty fields. Non-ASCII archetype names like \"The Nâgualisz\" parse correctly because the patterns moved from `[A-Z][a-z]+` to `\\p{Lu}\\p{Ll}+`.

Second checkbox of #199. Parent stays open while remaining items (section-ordering aware field parsers, extraction confidence, content-level fixture assertions) land separately.

## Gotchas

- `normalizeForMatching` keeps newlines so the splitter's line-anchored \"Choose Your Nature\" check and the `^...$` archetype patterns still work; only horizontal whitespace and typographic punctuation collapse.
- The non-ASCII edge-case test in `pdf.edge-cases.test.ts` flipped from pinning the bug (\"Unknown\") to asserting the fix (\"The Nâgualisz\"). The other three baselines in that file still pin behaviors this PR doesn't touch.

## Verification

- `npm test` — 184 passed, 6 skipped, 0 failed.