### PR TITLE
refactor(pdf): token stream foundation for parser refit

### DIFF
--- a/src/playbook/sources/tokenizer.ts
+++ b/src/playbook/sources/tokenizer.ts
@@ -1,0 +1,231 @@
+/**
+ * Token stream for the PDF playbook parser.
+ *
+ * Phase 1 of the tokenize → recursive-descent refactor tracked in #208.
+ * Owns the anchor heading table, whitespace normalization, and page
+ * boundaries. The recursive-descent parser (phase 2) consumes the token
+ * stream produced here; `pdf.ts`'s legacy regex-slice path also reads
+ * `SECTION_ANCHORS` from this module so both sides share one source of
+ * truth while the migration lands incrementally.
+ */
+
+import { normalizeForMatching } from "./debug";
+
+/**
+ * Stable internal names for the section anchors found inside a playbook.
+ *
+ * The string literal type lets the parser's dispatch loop be exhaustive over
+ * known anchors without smuggling raw heading text through the API.
+ */
+export type AnchorName =
+  | "ChooseYourNature"
+  | "Background"
+  | "WhereDoYouCallHome"
+  | "WhyAreYouAVagabond"
+  | "Moves"
+  | "Feats"
+  | "WeaponSkills"
+  | "Equipment"
+  | "Details"
+  | "Demeanor";
+
+interface AnchorDef {
+  name: AnchorName;
+  regex: RegExp;
+}
+
+/**
+ * Headings sit on their own line (or trailing-only content on the line) in
+ * extracted PDF text, so anchors require either a line boundary or a `?`
+ * terminator. `g` is set on every entry so the lexer can pick up multiple
+ * occurrences for first-wins resolution.
+ *
+ * Real playbooks use "Roguish Moves"; the audit on #199 confirmed
+ * "Starting Moves" never appears in surveyed content. Both forms anchor
+ * here so synthetic fixtures and real content both resolve.
+ */
+export const SECTION_ANCHORS: ReadonlyArray<AnchorDef> = [
+  { name: "ChooseYourNature", regex: /^[ \t]*Choose Your Nature[ \t]*$/gm },
+  { name: "Background", regex: /^[ \t]*Background[ \t]*$/gm },
+  { name: "WhereDoYouCallHome", regex: /Where do you call home\?/g },
+  { name: "WhyAreYouAVagabond", regex: /Why are you a vagabond\?/g },
+  { name: "Moves", regex: /^[ \t]*(?:Starting Moves|Roguish Moves)[ \t]*$/gm },
+  { name: "Feats", regex: /^[ \t]*Roguish Feats[ \t]*$/gm },
+  { name: "WeaponSkills", regex: /^[ \t]*Weapon Skills[ \t]*$/gm },
+  { name: "Equipment", regex: /^[ \t]*Equipment[ \t]*$/gm },
+  { name: "Details", regex: /^[ \t]*Details[ \t]*$/gm },
+  { name: "Demeanor", regex: /^[ \t]*Demeanor[ \t]*$/gm },
+];
+
+/**
+ * One token in the lexed playbook stream.
+ *
+ * `pos` is the offset into the normalized, page-joined document so the
+ * parser can produce position-anchored diagnostics (and reuse
+ * `createPositionHighlight` for log highlighting).
+ */
+export type Token =
+  | { type: "PageBreak"; page: number; pos: number }
+  | { type: "AnchorHeader"; name: AnchorName; raw: string; pos: number }
+  | { type: "BodyLine"; text: string; pos: number }
+  | { type: "Bullet"; pos: number };
+
+/** Page-joined, normalized document text plus the token stream over it. */
+export interface LexResult {
+  text: string;
+  tokens: Token[];
+}
+
+/**
+ * Lex the page array produced by the PDF extractor into a flat token stream.
+ *
+ * The lexer:
+ * 1. Joins pages with `\n` and emits a `PageBreak` token at each boundary so
+ *    the parser can use natural page breaks as a section hint (replaces the
+ *    old `splitPositionThreshold` magic number — landed in #204).
+ * 2. Normalizes typography and whitespace before matching anchors so smart
+ *    quotes / non-breaking spaces / variable runs of horizontal whitespace
+ *    don't defeat heading detection (#206).
+ * 3. Scans every `SECTION_ANCHORS` regex against the normalized text,
+ *    sorting hits by document position and dropping later occurrences of
+ *    the same anchor (first-wins). Each surviving hit becomes an
+ *    `AnchorHeader` token; the text between anchors is split into
+ *    `BodyLine` tokens, with leading bullet markers turned into a
+ *    `Bullet` token followed by the trailing line text. Empty lines are
+ *    skipped.
+ */
+export function tokenize(pages: string[]): LexResult {
+  const text = normalizeForMatching(pages.join("\n"));
+
+  const pageBreaks = computePageBreaks(pages);
+
+  const headerHits = scanAnchors(text);
+
+  const tokens: Token[] = [];
+
+  // Walk text segments between header hits, interleaving page breaks in
+  // position order so the final stream is monotonic in `pos`.
+  let cursor = 0;
+  let pageIdx = 0;
+
+  const emitPageBreaksUpTo = (limit: number): void => {
+    while (pageIdx < pageBreaks.length && pageBreaks[pageIdx]!.pos <= limit) {
+      tokens.push({
+        type: "PageBreak",
+        page: pageBreaks[pageIdx]!.page,
+        pos: pageBreaks[pageIdx]!.pos,
+      });
+      pageIdx++;
+    }
+  };
+
+  for (const hit of headerHits) {
+    emitPageBreaksUpTo(hit.matchStart);
+    if (hit.matchStart > cursor) {
+      emitBodyLines(text, cursor, hit.matchStart, tokens);
+    }
+    tokens.push({
+      type: "AnchorHeader",
+      name: hit.name,
+      raw: hit.raw,
+      pos: hit.matchStart,
+    });
+    cursor = hit.bodyStart;
+  }
+
+  emitPageBreaksUpTo(text.length);
+  if (cursor < text.length) {
+    emitBodyLines(text, cursor, text.length, tokens);
+  }
+
+  // Stable sort by position with a type tie-breaker. A page break at the
+  // same offset as the first body line of that page must sort before the
+  // line so consumers see "boundary, then content of new page."
+  const typePriority: Record<Token["type"], number> = {
+    PageBreak: 0,
+    AnchorHeader: 1,
+    Bullet: 2,
+    BodyLine: 3,
+  };
+  tokens.sort((a, b) => a.pos - b.pos || typePriority[a.type] - typePriority[b.type]);
+
+  return { text, tokens };
+}
+
+interface AnchorHit {
+  name: AnchorName;
+  matchStart: number;
+  bodyStart: number;
+  raw: string;
+}
+
+function scanAnchors(text: string): AnchorHit[] {
+  const hits: AnchorHit[] = [];
+  for (const { name, regex } of SECTION_ANCHORS) {
+    regex.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(text)) !== null) {
+      hits.push({
+        name,
+        matchStart: match.index,
+        bodyStart: match.index + match[0].length,
+        raw: match[0],
+      });
+      if (!regex.global) break;
+    }
+  }
+  hits.sort((a, b) => a.matchStart - b.matchStart);
+
+  // First occurrence wins — drop later duplicates and any anchor whose
+  // header sits inside a previously-claimed body span (e.g. a sidebar
+  // "Equipment" heading nested under a real Equipment section).
+  const seen = new Set<AnchorName>();
+  const claimed: AnchorHit[] = [];
+  for (const hit of hits) {
+    if (seen.has(hit.name)) continue;
+    seen.add(hit.name);
+    claimed.push(hit);
+  }
+  claimed.sort((a, b) => a.matchStart - b.matchStart);
+  return claimed;
+}
+
+function computePageBreaks(pages: string[]): Array<{ page: number; pos: number }> {
+  // Mirror `tokenize`'s join: page boundaries land on the `\n` separator
+  // between page i and page i+1 in the joined text. Normalization must not
+  // change `\n` boundaries, only horizontal whitespace and typographic chars,
+  // so byte-position math holds.
+  const breaks: Array<{ page: number; pos: number }> = [];
+  let pos = 0;
+  for (let i = 0; i < pages.length - 1; i++) {
+    const normalized = normalizeForMatching(pages[i] ?? "");
+    pos += normalized.length + 1; // +1 for the join `\n`
+    breaks.push({ page: i + 1, pos });
+  }
+  return breaks;
+}
+
+function emitBodyLines(text: string, start: number, end: number, tokens: Token[]): void {
+  const slice = text.slice(start, end);
+  let lineStart = 0;
+  while (lineStart < slice.length) {
+    const nl = slice.indexOf("\n", lineStart);
+    const lineEnd = nl === -1 ? slice.length : nl;
+    const rawLine = slice.slice(lineStart, lineEnd);
+    const trimmed = rawLine.trim();
+    if (trimmed.length > 0) {
+      const absPos = start + lineStart;
+      const bulletMatch = trimmed.match(/^([•·▪‣⁃])\s*(.*)$/);
+      if (bulletMatch) {
+        tokens.push({ type: "Bullet", pos: absPos });
+        const rest = bulletMatch[2]!.trim();
+        if (rest.length > 0) {
+          tokens.push({ type: "BodyLine", text: rest, pos: absPos });
+        }
+      } else {
+        tokens.push({ type: "BodyLine", text: trimmed, pos: absPos });
+      }
+    }
+    lineStart = nl === -1 ? slice.length : nl + 1;
+  }
+}

--- a/test/playbook/sources/tokenizer.test.ts
+++ b/test/playbook/sources/tokenizer.test.ts
@@ -1,0 +1,85 @@
+import { tokenize, SECTION_ANCHORS, type Token } from "../../../src/playbook/sources/tokenizer";
+
+describe("tokenize", () => {
+  it("emits no tokens for an empty page array", () => {
+    expect(tokenize([]).tokens).toEqual([]);
+  });
+
+  it("emits no tokens for whitespace-only pages", () => {
+    expect(tokenize(["   ", "\n\n"]).tokens.filter((t) => t.type !== "PageBreak")).toEqual([]);
+  });
+
+  it("emits BodyLine tokens for non-anchor text, skipping blank lines", () => {
+    const { tokens } = tokenize(["The Ranger\n\nlorem ipsum"]);
+    const bodies = tokens.filter(
+      (t): t is Extract<Token, { type: "BodyLine" }> => t.type === "BodyLine",
+    );
+    expect(bodies.map((t) => t.text)).toEqual(["The Ranger", "lorem ipsum"]);
+  });
+
+  it("emits AnchorHeader tokens for every entry in SECTION_ANCHORS", () => {
+    const text = [
+      "The Auditor",
+      "Choose Your Nature",
+      "Background",
+      "Where do you call home?",
+      "Why are you a vagabond?",
+      "Roguish Moves",
+      "Roguish Feats",
+      "Weapon Skills",
+      "Equipment",
+      "Details",
+      "Demeanor",
+    ].join("\n");
+    const headers = tokenize([text]).tokens.filter(
+      (t): t is Extract<Token, { type: "AnchorHeader" }> => t.type === "AnchorHeader",
+    );
+    expect(headers.map((h) => h.name)).toEqual(SECTION_ANCHORS.map((a) => a.name));
+  });
+
+  it("treats 'Starting Moves' and 'Roguish Moves' both as the Moves anchor", () => {
+    const a = tokenize(["Starting Moves\nfoo"]).tokens.find((t) => t.type === "AnchorHeader");
+    const b = tokenize(["Roguish Moves\nfoo"]).tokens.find((t) => t.type === "AnchorHeader");
+    expect(a).toMatchObject({ type: "AnchorHeader", name: "Moves" });
+    expect(b).toMatchObject({ type: "AnchorHeader", name: "Moves" });
+  });
+
+  it("keeps only the first occurrence of a duplicated anchor", () => {
+    const text = ["Equipment", "items", "Equipment", "more items"].join("\n");
+    const headers = tokenize([text]).tokens.filter((t) => t.type === "AnchorHeader");
+    expect(headers).toHaveLength(1);
+  });
+
+  it("orders tokens by document position", () => {
+    const { tokens } = tokenize([
+      "The Ranger\nChoose Your Nature\n+1 +2 +0 -1 +1\nBackground\nstuff",
+    ]);
+    const positions = tokens.map((t) => t.pos);
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+  });
+
+  it("emits a PageBreak between pages, with monotonic positions", () => {
+    const { tokens } = tokenize(["The Ranger", "The Thief"]);
+    const pageBreak = tokens.find((t) => t.type === "PageBreak");
+    expect(pageBreak).toMatchObject({ type: "PageBreak", page: 1 });
+    const positions = tokens.map((t) => t.pos);
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+  });
+
+  it("normalizes typography before matching anchors", () => {
+    // Non-breaking space inside the heading; smart quote in body. Real PDFs
+    // hand these out; the lexer must still resolve the anchor.
+    const text = "Where do you call home?\nlorem";
+    const headers = tokenize([text]).tokens.filter((t) => t.type === "AnchorHeader");
+    expect(headers).toHaveLength(1);
+    expect(headers[0]).toMatchObject({ name: "WhereDoYouCallHome" });
+  });
+
+  it("decomposes a bulleted line into a Bullet token followed by its body", () => {
+    const { tokens } = tokenize(["• fox"]);
+    const types = tokens.filter((t) => t.type !== "PageBreak").map((t) => t.type);
+    expect(types).toEqual(["Bullet", "BodyLine"]);
+    const body = tokens.find((t) => t.type === "BodyLine") as Extract<Token, { type: "BodyLine" }>;
+    expect(body.text).toBe("fox");
+  });
+});


### PR DESCRIPTION
## Summary

Adds the lexer that the recursive-descent parser refit (#208) is built
on. `tokenize(pages)` produces `AnchorHeader` / `BodyLine` / `Bullet`
/ `PageBreak` tokens over the page-joined, normalized document text.
The anchor heading table moves from \`pdf.ts\` into the new module
unchanged. Parser logic is unmodified in this PR — \`pdf.ts\`'s
existing regex-slice path keeps running, so all behaviour is preserved
while the foundation lands recoverably.

This is step 1 of the 6-step scope sketch in #208. Subsequent PRs port
\`parsePlaybooks\` onto the token stream, add per-field parser methods,
and surface the \`confidence\` accumulator on \`Playbook\`.

## Gotchas

- Page-break ordering: when a \`PageBreak\` shares an offset with the
  first \`BodyLine\` of the new page, the break must sort first. Token
  stream uses a stable sort with an explicit type tie-breaker
  (PageBreak < AnchorHeader < Bullet < BodyLine).
- The lexer applies first-wins anchor resolution at token-emit time
  rather than per-field, matching the semantics #207 introduced.

## Verification

- \`npm test\` — 196 passed, 6 skipped (unchanged from main).
- New \`tokenizer.test.ts\` covers empty/whitespace input, every
  \`SECTION_ANCHORS\` entry, the Starting/Roguish Moves alias,
  duplicate-anchor first-wins, monotonic positions, page breaks, and
  bullet decomposition (10 cases).