### PR TITLE
ci: validate PR titles against Conventional Commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,38 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,7 +1,7 @@
 name: PR Title
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -13,7 +13,6 @@ concurrency:
 
 jobs:
   validate:
-    name: Validate
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
## Summary

PR titles are now validated against the Conventional Commits spec in CI, so a malformed title fails the PR check before merge instead of silently dropping out of release-please's changelog generation.

Closes #184.

## Gotchas

- Branch protection on `master` is enabled but doesn't pin any required status checks. Marking this check required is a separate manual flip in repo settings — out of scope for this PR per acceptance criteria's "if branch protection is in use" qualifier.
- Workflow YAML isn't covered by local `check-yaml` / `yamllint` (both exclude `.github/workflows/`); #256 tracks adding actionlint coverage.

## Verification

- `pre-commit run --files .github/workflows/pr-title.yml` — passes.
- The action runs only against a real PR, so the "fails on malformed title / passes on valid title" acceptance criteria is observed on this PR's own check (its title is conventional → expect pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)