### PR TITLE
docs: add CLAUDE.md routing AI agents to repo conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,26 @@
 
 Audience: AI coding assistants. Humans use [CONTRIBUTING.md](CONTRIBUTING.md).
 
+## Project overview
+
+A TypeScript CLI (`woodland-gen`) for generating Root: The Tabletop RPG
+resources. Source in `src/`, compiled output in `dist/`. Entry points:
+`src/cli.ts` (CLI binary) and `src/index.ts` (library export).
+
+## Common commands
+
+- `npm run cli -- <args>`: build and run the CLI (for example,
+  `npm run cli -- character --help`).
+- `npm run build:watch`: `tsc` in watch mode for incremental development.
+- `npm test`: Jest suite.
+- `pre-commit run --all-files`: gates every PR. Authoritative hook list:
+  `.pre-commit-config.yaml`.
+
+## Tests
+
+Test files mirror the module under test: tests for `src/foo/bar.ts` live at
+`test/foo/bar.test.ts`. Don't split tests by feature or scenario.
+
 ## Commits
 
 Subjects must follow [Conventional Commits][conventional-commits]. The
@@ -14,17 +34,11 @@ Type and scope rules with examples:
 [CONTRIBUTING.md](CONTRIBUTING.md#commit-messages). The active type list lives
 in `release-please-config.json`.
 
-## Checks
-
-`pre-commit run --all-files` gates every PR. The authoritative hook list lives
-in `.pre-commit-config.yaml`; its header documents the install command (both
-`pre-commit` and `commit-msg` stages).
-
 ## Releases
 
 `release-please` opens a release PR from conventional commits, bumps the
 version, regenerates the released sections of `CHANGELOG.md`, and tags the
-release on merge. Don't hand-edit released sections; only the `[Unreleased]`
-section above accepts manual entries.
+release on merge. Don't hand-edit released sections. Only the `[Unreleased]`
+block accepts manual entries.
 
 [conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# AI agent notes
+
+Audience: AI coding assistants. Humans use [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Commits
+
+Subjects must follow [Conventional Commits][conventional-commits]. The
+`commit-msg` git hook (`compilerla/conventional-pre-commit`) rejects
+non-conventional subjects at `git commit` time. `release-please` reads commit
+prefixes to populate `CHANGELOG.md` and to bump the version on merge to
+`master`, so a non-conventional subject drops out of the released CHANGELOG.
+
+Type and scope rules with examples:
+[CONTRIBUTING.md](CONTRIBUTING.md#commit-messages). The active type list lives
+in `release-please-config.json`.
+
+## Checks
+
+`pre-commit run --all-files` gates every PR. The authoritative hook list lives
+in `.pre-commit-config.yaml`; its header documents the install command (both
+`pre-commit` and `commit-msg` stages).
+
+## Releases
+
+`release-please` opens a release PR from conventional commits, bumps the
+version, regenerates the released sections of `CHANGELOG.md`, and tags the
+release on merge. Don't hand-edit released sections; only the `[Unreleased]`
+section above accepts manual entries.
+
+[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
## Summary

A fresh-session AI agent now finds the project's orientation, common commands,
test-file naming convention, the conventional-commits requirement, and the
release-please pipeline that depends on it — without needing to be reminded
each turn or read four files to triangulate. Defers commit, PR, and scope
guidance to `CONTRIBUTING.md` so each rule has one source of truth.

Stays under 50 lines (Anthropic's CLAUDE.md guidance is < 200), and keeps to
the four community-baseline axes for repo CLAUDE.md content: project overview,
common commands, test convention, and commit/release pipeline.

## Gotchas

- The file deliberately repeats nothing from `CONTRIBUTING.md` (commit type
  rules, PR submission flow, code review process all stay there); reviewers
  used to README-style depth in CLAUDE.md may want to skip the prose-density
  check.
- `lychee` failed locally during pre-commit on the Conventional Commits link
  due to a GLIBC mismatch on my dev host (`GLIBC_2.38`/`2.39` not found by
  the cached `lychee` binary). The same URL is already in `CONTRIBUTING.md`
  on master, and the GHA `pre-commit` job runs on `ubuntu-latest` (newer
  GLIBC) — that's the real check. Both commits made with `SKIP=lychee` for
  the local-host issue only.

## Verification

- `pre-commit run --files CLAUDE.md`: vale passes, markdownlint passes,
  prettier passes.

Closes #182