### PR TITLE
docs: prune obsolete [Unreleased] block in root CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,6 @@ The format follows [Keep a CHANGELOG](https://keepachangelog.com/en/1.1.0/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Once [#217](https://github.com/alunduil/woodland-generators/issues/217) lands,
-release-please will manage per-package changelogs at
-`packages/<package>/CHANGELOG.md`, and this root file will carry project-level
-(cross-package) entries only.
-
 ## [0.2.0](https://github.com/alunduil/woodland-generators/compare/woodland-generators-v0.1.0...woodland-generators-v0.2.0) (2026-05-04)
 
 
@@ -49,21 +44,4 @@ release-please will manage per-package changelogs at
 * migrate from Dependabot to Renovate ([#143](https://github.com/alunduil/woodland-generators/issues/143)) ([2fc3b86](https://github.com/alunduil/woodland-generators/commit/2fc3b86d43b90d4d0a15538b4babff85bf154c70))
 * retire duplicate check:* npm scripts ([#186](https://github.com/alunduil/woodland-generators/issues/186)) ([68bddc4](https://github.com/alunduil/woodland-generators/commit/68bddc4c7ac47d50baefb5dff3ec42cfd7a896e3))
 * retire sync:deps script and sync-precommit workflow ([#172](https://github.com/alunduil/woodland-generators/issues/172)) ([ee3b437](https://github.com/alunduil/woodland-generators/commit/ee3b4379380d2b4369e694dfea3f1a7617f83870))
-
-## [Unreleased]
-
-> **v0.3.0 marks a pivot.** woodland-generators is being rebuilt as a FoundryVTT
-> module that generates Root: The Tabletop RPG session-zero content (clearings,
-> NPCs, factions, conflicts) directly into Scene/Actor/Journal entries. The
-> v0.2.0 CLI shape — PDF playbook ingestion and character generation — is being
-> retired; do not expect the v0.2.0 surface to remain in v0.3.0. See
-> [#210](https://github.com/alunduil/woodland-generators/issues/210) for the
-> full scope.
-
-### Changed
-
-- Repository converted to a pnpm workspace
-  ([#264](https://github.com/alunduil/woodland-generators/pull/264)) in
-  preparation for the `packages/core`, `packages/cli`, and
-  `packages/foundry-module` split.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format follows [Keep a CHANGELOG](https://keepachangelog.com/en/1.1.0/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Once [#217](https://github.com/alunduil/woodland-generators/issues/217) lands,
+release-please will manage per-package changelogs at
+`packages/<package>/CHANGELOG.md`, and this root file will carry project-level
+(cross-package) entries only.
+
 ## [0.2.0](https://github.com/alunduil/woodland-generators/compare/woodland-generators-v0.1.0...woodland-generators-v0.2.0) (2026-05-04)
 
 
@@ -47,29 +52,18 @@ this project adheres to
 
 ## [Unreleased]
 
-### Added
+> **v0.3.0 marks a pivot.** woodland-generators is being rebuilt as a FoundryVTT
+> module that generates Root: The Tabletop RPG session-zero content (clearings,
+> NPCs, factions, conflicts) directly into Scene/Actor/Journal entries. The
+> v0.2.0 CLI shape — PDF playbook ingestion and character generation — is being
+> retired; do not expect the v0.2.0 surface to remain in v0.3.0. See
+> [#210](https://github.com/alunduil/woodland-generators/issues/210) for the
+> full scope.
 
-- CLI tool for generating Root: The Tabletop RPG resources (`woodland-gen`
-  command)
-- Character generation with `character` sub-command (alias: `char`)
-- PDF playbook parsing support for Root RPG playbook files
-- Comprehensive character generation from playbook PDF files including:
-  - Species generation with traits and details
-  - Name generation for woodland creatures
-  - Background, feat, and move generation
-  - Playbook-specific archetype selection
-  - Character details generation (pronouns, appearance, accessories)
-  - Demeanor traits drawn from playbook personality options
-- Reproducible character generation via `--seed` option
-- Custom name override via `--name` option
-- Specific archetype selection via `--archetype` option
-- Multi-source playbook support (PDF and JSON formats)
-- Global installation support via npm
-- Extended woodland species catalog (100+ species) for enhanced character
-  diversity when playbooks include "other" species option
-- `--log-level` option for controlling diagnostic output verbosity with support
-  for standard log levels (trace, debug, info, warn, error, fatal)
-- `--species` option for character command to override species selection
-- Structured logging throughout generation pipeline for debugging generation
-  failures
-- Requires Node.js 20.0.0 or later
+### Changed
+
+- Repository converted to a pnpm workspace
+  ([#264](https://github.com/alunduil/woodland-generators/pull/264)) in
+  preparation for the `packages/core`, `packages/cli`, and
+  `packages/foundry-module` split.
+


### PR DESCRIPTION
## Summary

Removes a stale hand-written `[Unreleased]` block from `CHANGELOG.md` that described the pre-v0.2.0 PDF-playbook product. It's leftover from before release-please was adopted (#180), and release-please doesn't manage `[Unreleased]` — it only autogenerates `## [version]` sections — so the block has been decaying ever since. Pruning leaves the file at "intro + autogenerated version sections", which is what release-please will continue prepending to.

## Gotchas

- Two commits on this branch: 444a66f (a misframed re-baseline that added forward-looking pivot prose — a CHANGELOG anti-pattern) and the follow-up that strips both the new forward-looking content and the original stale block. Squash-merge collapses them. Reviewing the squashed diff is enough; the per-commit history is just the realisation arc.
- v0.3.0's pivot signal is **not** in this PR — it'll come from `!`-marked breaking-change commits (`refactor!:` / `revert!:` / `feat!:`) on the pivot PRs, which release-please surfaces prominently in the autogenerated v0.3.0 section.
- Per-package CHANGELOG paths are out of scope here; #217 handles that via release-please config.

Closes #222.