### PR TITLE
chore: deflect questions to GitHub Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+contact_links:
+  - name: Question or help request
+    url: https://github.com/alunduil/woodland-generators/discussions/categories/q-a
+    about: Ask the community for help or how-to questions.
+  - name: Idea or proposal (not yet a commitment)
+    url: https://github.com/alunduil/woodland-generators/discussions/categories/ideas
+    about: Float a feature idea before opening a feature request.
+  - name: General discussion
+    url: https://github.com/alunduil/woodland-generators/discussions/categories/general
+    about: Anything else that isn't a bug or feature request.


### PR DESCRIPTION
## Summary

Issue creation page now shows three Discussions contact links (Q&A, Ideas, General) above the bug/feature templates, deflecting non-bug, non-work-item conversations from the issue tracker.

## Gotchas

Discussions and the named categories are already enabled on the repo (verified via `gh api repos/.../discussionCategories`), so this PR adds no repo-settings change — only `.github/ISSUE_TEMPLATE/config.yml`. The issue picker rendering can only be visually confirmed once merged to the default branch.

Closes #219