### PR TITLE
feat(cli): add character subcommand wrapping generateCharacter

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,6 +4,7 @@ import { Command, Option } from "commander";
 import { root } from "@woodland-generators/core";
 import packageJson from "../package.json";
 import pino from "pino";
+import { createCharacterCommand } from "./commands/character";
 import { createNameCommand } from "./commands/name";
 
 const program = new Command();
@@ -26,6 +27,7 @@ program.hook("preAction", (thisCommand) => {
   }
 });
 
+program.addCommand(createCharacterCommand());
 program.addCommand(createNameCommand());
 
 process.on("unhandledRejection", (reason) => {

--- a/packages/cli/src/commands/character.ts
+++ b/packages/cli/src/commands/character.ts
@@ -1,0 +1,51 @@
+import { Command } from "commander";
+import { generateCharacter } from "@woodland-generators/core";
+import { randomBytes } from "crypto";
+
+const collect = (value: string, previous: string[]): string[] => [...previous, value];
+
+interface CharacterCommandOptions {
+  seed?: string;
+  archetype: string;
+  speciesChoice: string[];
+  demeanorChoice: string[];
+  detailsPronoun: string[];
+  detailsAppearance: string[];
+  detailsAccessory: string[];
+  name?: string;
+  species?: string;
+  demeanor: string[];
+}
+
+export function createCharacterCommand(): Command {
+  return new Command("character")
+    .description("Generate a character and print it as JSON")
+    .option("-s, --seed <seed>", "seed for reproducible generation")
+    .requiredOption("--archetype <archetype>", "archetype label written onto the character")
+    .option("--species-choice <s>", "species choice (repeatable)", collect, [])
+    .option("--demeanor-choice <s>", "demeanor choice (repeatable)", collect, [])
+    .option("--details-pronoun <s>", "pronoun choice (repeatable)", collect, [])
+    .option("--details-appearance <s>", "appearance choice (repeatable)", collect, [])
+    .option("--details-accessory <s>", "accessory choice (repeatable)", collect, [])
+    .option("--name <name>", "user-provided name (passes through verbatim)")
+    .option("--species <species>", "user-provided species override")
+    .option("--demeanor <s>", "user-provided demeanor trait (repeatable)", collect, [])
+    .action(async (options: CharacterCommandOptions): Promise<void> => {
+      const seed = options.seed ?? randomBytes(8).toString("hex");
+      const character = await generateCharacter({
+        seed,
+        archetype: options.archetype,
+        speciesChoices: options.speciesChoice,
+        demeanorChoices: options.demeanorChoice,
+        detailsChoices: {
+          pronouns: options.detailsPronoun,
+          appearance: options.detailsAppearance,
+          accessories: options.detailsAccessory,
+        },
+        ...(options.name !== undefined && { name: options.name }),
+        ...(options.species !== undefined && { species: options.species }),
+        ...(options.demeanor.length > 0 && { demeanor: options.demeanor }),
+      });
+      process.stdout.write(JSON.stringify({ seed, ...character }) + "\n");
+    });
+}

--- a/packages/cli/test/commands/character.test.ts
+++ b/packages/cli/test/commands/character.test.ts
@@ -1,0 +1,98 @@
+import { createCharacterCommand } from "../../src/commands/character";
+
+const baseArgs = [
+  "--archetype",
+  "The Ranger",
+  "--species-choice",
+  "mouse",
+  "--species-choice",
+  "fox",
+  "--demeanor-choice",
+  "Curious",
+  "--demeanor-choice",
+  "Brave",
+  "--details-pronoun",
+  "they",
+  "--details-appearance",
+  "scarred",
+  "--details-accessory",
+  "satchel",
+];
+
+interface CharacterPayload {
+  seed: string;
+  name: string;
+  playbook: string;
+  species: string;
+  details: { pronouns: string[]; appearance: string[]; accessories: string[] };
+  demeanor: string[];
+}
+
+describe("character command", () => {
+  let stdoutSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    stdoutSpy = jest.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+  });
+
+  it("emits a single-line JSON character with seed and core fields", async () => {
+    const cmd = createCharacterCommand();
+    await cmd.parseAsync(["--seed", "fixture-seed", ...baseArgs], { from: "user" });
+
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    const written = stdoutSpy.mock.calls[0][0] as string;
+    expect(written.endsWith("\n")).toBe(true);
+    expect(written.slice(0, -1).includes("\n")).toBe(false);
+
+    const payload = JSON.parse(written) as CharacterPayload;
+    expect(payload.seed).toBe("fixture-seed");
+    expect(payload.playbook).toBe("The Ranger");
+    expect(typeof payload.name).toBe("string");
+    expect(["mouse", "fox"]).toContain(payload.species);
+    expect(payload.details.pronouns).toEqual(["they"]);
+    expect(payload.details.appearance).toEqual(["scarred"]);
+    expect(payload.details.accessories).toEqual(["satchel"]);
+    payload.demeanor.forEach((trait) => expect(["Curious", "Brave"]).toContain(trait));
+  });
+
+  it("is reproducible across runs with the same flags", async () => {
+    const cmd1 = createCharacterCommand();
+    await cmd1.parseAsync(["--seed", "deterministic", ...baseArgs], { from: "user" });
+    const first = stdoutSpy.mock.calls[0][0] as string;
+
+    stdoutSpy.mockClear();
+
+    const cmd2 = createCharacterCommand();
+    await cmd2.parseAsync(["--seed", "deterministic", ...baseArgs], { from: "user" });
+    const second = stdoutSpy.mock.calls[0][0] as string;
+
+    expect(first).toBe(second);
+  });
+
+  it("passes user overrides through verbatim", async () => {
+    const cmd = createCharacterCommand();
+    await cmd.parseAsync(
+      [
+        "--seed",
+        "any",
+        ...baseArgs,
+        "--name",
+        "Rosalind",
+        "--species",
+        "fox",
+        "--demeanor",
+        "Curious",
+      ],
+      { from: "user" },
+    );
+
+    const payload = JSON.parse(stdoutSpy.mock.calls[0][0] as string) as CharacterPayload;
+    expect(payload.name).toBe("Rosalind");
+    expect(payload.species).toBe("fox");
+    expect(payload.demeanor).toEqual(["Curious"]);
+  });
+});


### PR DESCRIPTION
## Summary
`woodland-gen character` now wraps `generateCharacter`, exposing the headline composite generator on the CLI for headless verification and scripting. Closes #274.

## Verification
- Ran the acceptance example end-to-end against the built bin; output is a single-line JSON character with `seed`, `name`, `playbook`, `species`, `details`, `demeanor`.
- Re-running with the same flags produces byte-identical output (covered by the reproducibility test).
- `woodland-gen --help` lists `character` alongside `name`.
- `pnpm --filter @woodland-generators/cli test` and `pre-commit run` on the changed files pass.