### PR TITLE
ci: matrix tests by package × Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: Test (Node ${{ matrix.node-version }})
+    name: Test (${{ matrix.package }}, Node ${{ matrix.node-version }})
     timeout-minutes: 15
 
     strategy:
@@ -28,8 +28,13 @@ jobs:
         # supported-line coverage. Codecov gates on `lts/*` to anchor the
         # signal to active LTS rather than rotating through maintenance.
         node-version: ["lts/-2", "lts/-1", "lts/*"]
+        package: [core, cli]
         include:
           - node-version: "lts/*"
+            package: core
+            coverage: true
+          - node-version: "lts/*"
+            package: cli
             coverage: true
 
     steps:
@@ -42,15 +47,15 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Run tests with coverage
-        run: pnpm run test:coverage
+        run: pnpm --filter @woodland-generators/${{ matrix.package }} run test:coverage
 
       - name: Upload coverage to Codecov
         if: matrix.coverage
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
-          files: ./packages/core/coverage/lcov.info
-          flags: unittests
-          name: codecov-umbrella
+          files: ./packages/${{ matrix.package }}/coverage/lcov.info
+          flags: ${{ matrix.package }}
+          name: codecov-${{ matrix.package }}
           fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -59,9 +64,9 @@ jobs:
         if: always() && matrix.coverage
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         with:
-          files: ./packages/core/test-results/junit.xml
-          flags: unittests
-          name: test-results
+          files: ./packages/${{ matrix.package }}/test-results/junit.xml
+          flags: ${{ matrix.package }}
+          name: test-results-${{ matrix.package }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,6 @@ jobs:
         # signal to active LTS rather than rotating through maintenance.
         node-version: ["lts/-2", "lts/-1", "lts/*"]
         package: [core, cli]
-        include:
-          - node-version: "lts/*"
-            package: core
-            coverage: true
-          - node-version: "lts/*"
-            package: cli
-            coverage: true
 
     steps:
       - name: Checkout code
@@ -50,7 +43,7 @@ jobs:
         run: pnpm --filter @woodland-generators/${{ matrix.package }} run test:coverage
 
       - name: Upload coverage to Codecov
-        if: matrix.coverage
+        if: matrix.node-version == 'lts/*'
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           files: ./packages/${{ matrix.package }}/coverage/lcov.info
@@ -61,7 +54,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
-        if: always() && matrix.coverage
+        if: always() && matrix.node-version == 'lts/*'
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         with:
           files: ./packages/${{ matrix.package }}/test-results/junit.xml


### PR DESCRIPTION
## Summary

CI test matrix now fans out by package as well as Node version, so a per-package failure surfaces as a named slot (e.g. `Test (core, Node lts/*)`) instead of the prior `Test (Node lts/*)` running `pnpm -r` and obscuring which package broke. Codecov uploads are package-scoped (`flags: core`, `flags: cli`) so per-package coverage history is preserved as more packages land.

The pnpm install + cache half of #216 already shipped via #264 — this PR closes the remaining "per-package matrix" half.

## Gotchas

- The matrix is the full cross product: `["lts/-2", "lts/-1", "lts/*"] × [core, cli]` = 6 jobs (was 3). pnpm cache should keep the per-job overhead bounded; flag if wall-clock regresses noticeably.
- `include:` extends the existing `lts/* × {core, cli}` slots with `coverage: true` rather than creating new slots — relies on the matrix-include merge semantics where matching key combinations get values added in place.
- Does not touch the Codecov path-remapping question (lcov `SF:` lines are package-relative, not repo-relative). That's #272 territory; flagged on master independently.

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)