### PR TITLE
build(test): emit repo-relative lcov SF paths via reporter projectRoot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,20 @@ jobs:
       - name: Run tests with coverage
         run: pnpm run test:coverage
 
+      # Per-package jest writes SF: lines relative to packages/<pkg>/, so
+      # uploaded paths land as src/foo.ts and miss codecov.yml's repo-relative
+      # ignore patterns and Codecov's PR diff overlay. Prefix each lcov in
+      # place so paths align with the rest of the repo.
+      - name: Rewrite lcov paths to repo-relative
+        if: matrix.coverage
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for lcov in packages/*/coverage/lcov.info; do
+            pkg=$(dirname "$(dirname "$lcov")")
+            sed -i "s|^SF:|SF:${pkg}/|" "$lcov"
+          done
+
       - name: Upload coverage to Codecov
         if: matrix.coverage
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,20 +44,6 @@ jobs:
       - name: Run tests with coverage
         run: pnpm run test:coverage
 
-      # Per-package jest writes SF: lines relative to packages/<pkg>/, so
-      # uploaded paths land as src/foo.ts and miss codecov.yml's repo-relative
-      # ignore patterns and Codecov's PR diff overlay. Prefix each lcov in
-      # place so paths align with the rest of the repo.
-      - name: Rewrite lcov paths to repo-relative
-        if: matrix.coverage
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          for lcov in packages/*/coverage/lcov.info; do
-            pkg=$(dirname "$(dirname "$lcov")")
-            sed -i "s|^SF:|SF:${pkg}/|" "$lcov"
-          done
-
       - name: Upload coverage to Codecov
         if: matrix.coverage
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6

--- a/packages/cli/jest.config.json
+++ b/packages/cli/jest.config.json
@@ -4,7 +4,7 @@
   "clearMocks": true,
   "collectCoverageFrom": ["src/**/*.ts", "!src/**/*.d.ts"],
   "testPathIgnorePatterns": ["/node_modules/", "/dist/"],
-  "coverageReporters": ["text", "lcov", "html"],
+  "coverageReporters": ["text", ["lcov", { "projectRoot": "../.." }], "html"],
   "reporters": [
     "default",
     [

--- a/packages/core/jest.config.json
+++ b/packages/core/jest.config.json
@@ -4,7 +4,7 @@
   "clearMocks": true,
   "collectCoverageFrom": ["src/**/*.ts", "!src/**/*.d.ts"],
   "testPathIgnorePatterns": ["/node_modules/", "/dist/", ".*\\.bench\\.ts$"],
-  "coverageReporters": ["text", "lcov", "html"],
+  "coverageReporters": ["text", ["lcov", { "projectRoot": "../.." }], "html"],
   "reporters": [
     "default",
     [


### PR DESCRIPTION
## Summary

Codecov's PR diff overlay and `codecov.yml`'s `ignore:` patterns now line up with the repo because each package's lcov emits repo-relative `SF:` lines directly.

## Gotchas

The fix is a one-line change to each package's `jest.config.json` — pass `projectRoot: "../.."` to istanbul-reports' lcov reporter. The reporter writes `SF:` via `path.relative(projectRoot, fc.path)` ([istanbul-reports lcovonly/index.js:33](https://github.com/istanbuljs/istanbuljs/blob/main/packages/istanbul-reports/lib/lcovonly/index.js#L33)), so a relative `../..` resolves against pnpm's per-package cwd to the repo root and SF lines come out as `packages/<pkg>/src/...`. No CI shell surgery, no `codecov.yml` `fixes:` (which can't scope per-package and would collide once `packages/cli` uploads via #281), no jest `rootDir` gymnastics.

Per-package `jest.config.json` duplication is two lines total; clean enough that a shared base config isn't worth it yet.

Stacks under #281 without conflict — only `packages/*/jest.config.json` touched, no overlap with the matrix rewrite.

## Verification

- `pnpm --filter @woodland-generators/core run test:coverage`: `SF:packages/core/src/index.ts` (was `SF:src/index.ts`).
- `pnpm run test:coverage` (workspace-recursive): cli emits `SF:packages/cli/src/cli.ts`, core emits `SF:packages/core/src/index.ts`.
- `pre-commit run --files` clean on all three changed files.
- End-to-end Codecov overlay rendering verifies on the PR run itself.

Closes #272