### PR TITLE
chore: per-package release-please manifest mode

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,4 @@
 {
-  ".": "0.2.0"
+  "packages/core": "0.0.0",
+  "packages/cli": "0.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,31 +7,44 @@
   "bump-patch-for-minor-pre-major": false,
   "draft": false,
   "prerelease": false,
-  "changelog-sections": [
-    { "type": "feat", "section": "Added" },
-    { "type": "fix", "section": "Fixed" },
-    { "type": "perf", "section": "Changed" },
-    { "type": "refactor", "section": "Changed" },
-    { "type": "revert", "section": "Removed" },
-    { "type": "docs", "section": "Documentation" },
-    { "type": "chore", "section": "Maintenance" },
-    { "type": "ci", "section": "Maintenance", "hidden": true },
-    { "type": "build", "section": "Maintenance", "hidden": true },
-    { "type": "test", "section": "Maintenance", "hidden": true },
-    { "type": "style", "section": "Maintenance", "hidden": true }
-  ],
   "packages": {
     "packages/core": {
       "release-type": "node",
       "package-name": "@woodland-generators/core",
       "component": "core",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "changelog-sections": [
+        { "type": "feat", "section": "Added" },
+        { "type": "fix", "section": "Fixed" },
+        { "type": "perf", "section": "Changed" },
+        { "type": "refactor", "section": "Changed" },
+        { "type": "revert", "section": "Removed" },
+        { "type": "docs", "section": "Documentation" },
+        { "type": "chore", "section": "Maintenance" },
+        { "type": "build", "section": "Maintenance" },
+        { "type": "ci", "section": "Maintenance", "hidden": true },
+        { "type": "test", "section": "Maintenance", "hidden": true },
+        { "type": "style", "section": "Maintenance", "hidden": true }
+      ]
     },
     "packages/cli": {
       "release-type": "node",
       "package-name": "@woodland-generators/cli",
       "component": "cli",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "changelog-sections": [
+        { "type": "feat", "section": "Added" },
+        { "type": "fix", "section": "Fixed" },
+        { "type": "perf", "section": "Changed" },
+        { "type": "refactor", "section": "Changed" },
+        { "type": "revert", "section": "Removed" },
+        { "type": "docs", "section": "Documentation" },
+        { "type": "chore", "section": "Maintenance", "hidden": true },
+        { "type": "build", "section": "Maintenance", "hidden": true },
+        { "type": "ci", "section": "Maintenance", "hidden": true },
+        { "type": "test", "section": "Maintenance", "hidden": true },
+        { "type": "style", "section": "Maintenance", "hidden": true }
+      ]
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,29 +1,37 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "tag-separator": "@",
+  "include-v-in-tag": false,
+  "separate-pull-requests": true,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": false,
+  "draft": false,
+  "prerelease": false,
+  "changelog-sections": [
+    { "type": "feat", "section": "Added" },
+    { "type": "fix", "section": "Fixed" },
+    { "type": "perf", "section": "Changed" },
+    { "type": "refactor", "section": "Changed" },
+    { "type": "revert", "section": "Removed" },
+    { "type": "docs", "section": "Documentation" },
+    { "type": "chore", "section": "Maintenance" },
+    { "type": "ci", "section": "Maintenance", "hidden": true },
+    { "type": "build", "section": "Maintenance", "hidden": true },
+    { "type": "test", "section": "Maintenance", "hidden": true },
+    { "type": "style", "section": "Maintenance", "hidden": true }
+  ],
   "packages": {
-    ".": {
+    "packages/core": {
       "release-type": "node",
-      "package-name": "woodland-generators",
-      "changelog-path": "CHANGELOG.md",
-      "bootstrap-sha": "37dbd86bebdefca7f9d15490ad0bff5d79d49916",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false,
-      "draft": false,
-      "prerelease": false,
-      "include-v-in-tag": true,
-      "changelog-sections": [
-        { "type": "feat", "section": "Added" },
-        { "type": "fix", "section": "Fixed" },
-        { "type": "perf", "section": "Changed" },
-        { "type": "refactor", "section": "Changed" },
-        { "type": "revert", "section": "Removed" },
-        { "type": "docs", "section": "Documentation" },
-        { "type": "chore", "section": "Maintenance" },
-        { "type": "ci", "section": "Maintenance", "hidden": true },
-        { "type": "build", "section": "Maintenance", "hidden": true },
-        { "type": "test", "section": "Maintenance", "hidden": true },
-        { "type": "style", "section": "Maintenance", "hidden": true }
-      ]
+      "package-name": "@woodland-generators/core",
+      "component": "core",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "packages/cli": {
+      "release-type": "node",
+      "package-name": "@woodland-generators/cli",
+      "component": "cli",
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }


### PR DESCRIPTION
## Summary

Per-package release cadence: `core` and `cli` each own their semver line and open their own release PR. Tags are namespaced (`core@x.y.z`, `cli@x.y.z`), so a fix in `core` no longer forces a speculative bump on `cli`. Changelog sections are tuned per audience — `core` (library consumers) surfaces `chore` (dep bumps) and `build` (emit/target shifts); `cli` (end users) hides both.

## Gotchas

- The root `.` entry is dropped from the manifest. The historical `woodland-generators-v0.2.0` tag stays on the repo as an archive marker — release-please will simply ignore it (no matching component).
- Both packages start at `0.0.0`. `bootstrap-sha` is intentionally unset, so the first release-please run will scan path-filtered history per package; the first release should bump each to `0.1.0` (extraction commits are `refactor!`, which `bump-minor-pre-major: true` lifts to a minor).
- `chore(deps)` only surfaces in a package's changelog when the commit touches that package's `package.json`. Renovate already updates each `packages/*/package.json` that depends on the bumped package (verified against recent commits), so shared-dep bumps land in both changelogs and `core`-only deps land only in `core`. Lockfile-only commits stay invisible to either, which is the desired outcome.
- The root `CHANGELOG.md` is left in place as the archival record of the pre-monorepo 0.x line. README/CONTRIBUTING references to `CHANGELOG.md` still resolve.

## Verification

- `pre-commit run --files release-please-config.json .release-please-manifest.json` passes (json-check + prettier).
- Spot-checked recent Renovate commits to confirm path attribution: e.g. `0e28668` (jest v30) touched `packages/core/package.json`; `d5c33ac` (pino v10) likewise.

Closes #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)