### PR TITLE
ci: depcheck audits every workspace package

### DIFF
--- a/.depcheckrc.json
+++ b/.depcheckrc.json
@@ -1,0 +1,3 @@
+{
+  "ignores": ["depcheck", "prettier"]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -130,15 +130,15 @@ repos:
         pass_filenames: false
         types: [ts]
       - id: depcheck
-        # depcheck only sees devDeps referenced via package.json scripts. The
-        # hook invocations here don't count, so depcheck would flag itself.
-        # prettier is referenced from .prettierrc, which depcheck's prettier
-        # special only checks for the `prettier` field in package.json.
+        # Audits the root and every workspace package. Per-package ignores
+        # live in each package's `.depcheckrc.json`; only the root needs one
+        # today (depcheck and prettier are devDeps used via tool config, not
+        # imports, so depcheck can't see them).
         name: depcheck
-        entry: pnpm exec depcheck --ignores=depcheck,prettier
+        entry: pnpm -r --include-workspace-root exec depcheck
         language: system
         pass_filenames: false
-        files: ^(package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml)$
+        files: (^|/)package\.json$|^pnpm-lock\.yaml$|^pnpm-workspace\.yaml$|(^|/)\.depcheckrc\.json$
       - id: workspace
         name: workspace
         entry: pnpm exec tsx scripts/validate-workspace.ts


### PR DESCRIPTION
## Summary

`pre-commit run depcheck` now audits the root and every `packages/*` package, so an unused or missing dep in `packages/core` or `packages/cli` fails the hook the same way a root-level drift does.

## Gotchas

- Per-package ignore lists live in each package's `.depcheckrc.json`. Today only the root needs one (`depcheck` and `prettier` are devDeps used via tool config, not imports). Future packages add their own `.depcheckrc.json` rather than appending flags to `.pre-commit-config.yaml`.
- Hook trigger broadened from root-only to any `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, or `.depcheckrc.json`. Cost: ~1 extra depcheck invocation per workspace package on a manifest change.

## Verification

- Ran `pre-commit run depcheck --all-files` on a clean tree — passed.
- Injected an unused dep in `packages/core/package.json` and ran the hook against just that file — failed as `Unused dependencies: bogus-unused-dep`.
- Deleted `just-percentile` from `packages/core/package.json` (still imported in `packages/core/src/maths/stats.ts`) — failed as `Missing dependencies: just-percentile`.
- Same injection in `packages/cli/package.json` — failed.

Closes #273.