### PR TITLE
build: switch tsconfig to node16 module resolution

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,8 +2,9 @@
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2022"],
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "isolatedModules": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,6 @@
     "pnpm": ">=10.0.0"
   },
   "dependencies": {
-    "just-percentile": "^4.2.0",
     "pino": "^10.0.0",
     "pino-pretty": "^13.1.1",
     "seeded-random-utilities": "^1.1.4"

--- a/packages/core/src/details/index.ts
+++ b/packages/core/src/details/index.ts
@@ -2,4 +2,4 @@
  * Details domain module
  */
 
-export { Details } from "./types";
+export type { Details } from "./types";

--- a/packages/core/src/maths/stats.ts
+++ b/packages/core/src/maths/stats.ts
@@ -1,4 +1,10 @@
-import percentile from "just-percentile";
+function percentile(sorted: number[], p: number): number {
+  const idx = (sorted.length - 1) * p;
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sorted[lo]!;
+  return sorted[lo]! + (sorted[hi]! - sorted[lo]!) * (idx - lo);
+}
 
 /**
  * Statistical summary information for a numeric dataset

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,8 +2,9 @@
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2022"],
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "isolatedModules": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,6 @@ importers:
 
   packages/core:
     dependencies:
-      just-percentile:
-        specifier: ^4.2.0
-        version: 4.2.0
       pino:
         specifier: ^10.0.0
         version: 10.3.1
@@ -1812,9 +1809,6 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
-
-  just-percentile@4.2.0:
-    resolution: {integrity: sha512-DjoYlegU7nyyi9ux9atRphMx4plC1fPgeSPkOvjg6Y3QzOx91jwi/6BDmgdb+KYBiI2glRWgHriA98NI/OWaBQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -4614,8 +4608,6 @@ snapshots:
   json-stringify-safe@5.0.1: {}
 
   json5@2.2.3: {}
-
-  just-percentile@4.2.0: {}
 
   keyv@4.5.4:
     dependencies:


### PR DESCRIPTION
## Summary

Repository builds cleanly under TypeScript 6.0 — both packages migrate from
the deprecated `moduleResolution: node10` (legacy alias `node`) to `node16`,
with `isolatedModules: true` as the recommended companion for Node CommonJS
emit. Compiled output stays CJS (no `"type": "module"`).

Unblocks #251 (Renovate's TS 5.9 → 6 bump), whose `Test`, `Performance
Benchmarks`, and `Pre-commit` checks all collapse to the same TS5107
deprecation error.

## Gotchas

- Focus on `packages/core/src/maths/stats.ts`. The stricter `node16`
  resolver flagged `just-percentile` as ESM-only via its `"type": "module"`
  declaration, even though it ships a `require` export that worked under
  `node10`. Inlined a 7-line linear-interpolation percentile instead of
  forcing `summary()` to become async via `import()`. Algorithm matches
  `just-percentile`'s output for every existing hardcoded test case
  (`[1,5]`, `[1,2,3,4,5]`, `[1,2,3,4,5,6]`).
- `isolatedModules: true` required one `export type` fix in
  `packages/core/src/details/index.ts` — no other source-level fallout.

## Verification

- Ran `tsc --noEmit -p <each>` against all five workspace tsconfigs under
  TypeScript 6.0.3 (temporarily installed) — all clean.
- Ran `pnpm test` under both pinned 5.9.3 and 6.0.3 — 107 passed, 6 skipped,
  0 failed; ts-jest TS151002 warning gone after `isolatedModules: true`.
- Ran `pre-commit run --files <changed>` — all hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)