### PR TITLE
ci: validate ADR status at pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -145,3 +145,9 @@ repos:
         language: system
         pass_filenames: false
         files: ^(\.vscode/extensions\.json|\.devcontainer/devcontainer\.json|scripts/validate-workspace\.ts)$
+      - id: validate-adrs
+        name: validate-adrs
+        entry: pnpm exec tsx scripts/validate-adrs.ts
+        language: system
+        pass_filenames: false
+        files: ^(docs/adr/.*\.md|scripts/validate-adrs\.ts)$

--- a/docs/adr/0000-record-architecture-decisions.md
+++ b/docs/adr/0000-record-architecture-decisions.md
@@ -24,10 +24,10 @@ lightweight format from Michael Nygard's [Documenting Architecture
 Decisions][nygard]. ADRs live under `docs/adr/` as `NNNN-kebab-title.md`,
 numbered from 0000 (this record).
 
-Each ADR carries a `Status`: `Accepted`, `Deprecated`, `Superseded by NNNN`, or
-`Amended by NNNN`. ADRs land as `Accepted`—the PR review is the deliberation,
-not the committed status field. `scripts/validate-adrs.ts` enforces the allowed
-values.
+Each ADR carries a `Status`: `Accepted`, `Deprecated`, or `Superseded by NNNN`,
+matching Michael Nygard's original four (minus `Proposed`). ADRs land as
+`Accepted`—the PR review is the deliberation, not the committed status field.
+`scripts/validate-adrs.ts` enforces the allowed values.
 
 An ADR is warranted when a decision is significant _and_ hard to reverse.
 Tactical choices, reversible defaults, and personal style belong in the commit

--- a/docs/adr/0000-record-architecture-decisions.md
+++ b/docs/adr/0000-record-architecture-decisions.md
@@ -4,7 +4,7 @@ Date: 2026-05-10
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -24,9 +24,10 @@ lightweight format from Michael Nygard's [Documenting Architecture
 Decisions][nygard]. ADRs live under `docs/adr/` as `NNNN-kebab-title.md`,
 numbered from 0000 (this record).
 
-Each ADR carries a `Status`: `Proposed`, `Accepted`, `Superseded by NNNN`, or
-`Deprecated`. New ADRs land as `Proposed`. Maintainers promote on merge or
-review.
+Each ADR carries a `Status`: `Accepted`, `Deprecated`, `Superseded by NNNN`, or
+`Amended by NNNN`. ADRs land as `Accepted`—the PR review is the deliberation,
+not the committed status field. `scripts/validate-adrs.ts` enforces the allowed
+values.
 
 An ADR is warranted when a decision is significant _and_ hard to reverse.
 Tactical choices, reversible defaults, and personal style belong in the commit

--- a/docs/adr/0001-coexist-with-magpie-root.md
+++ b/docs/adr/0001-coexist-with-magpie-root.md
@@ -4,7 +4,7 @@ Date: 2026-05-10
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/scripts/validate-adrs.ts
+++ b/scripts/validate-adrs.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 
 const ADR_DIR = join(process.cwd(), "docs", "adr");
 const FILENAME_RE = /^(\d{4})-[a-z0-9]+(?:-[a-z0-9]+)*\.md$/;
-const STATUS_RE = /^(Accepted|Deprecated|Superseded by \d{4}|Amended by \d{4})$/;
+const STATUS_RE = /^(Accepted|Deprecated|Superseded by \d{4})$/;
 const REQUIRED_SECTIONS = ["Status", "Context", "Decision", "Consequences"];
 
 const errors: string[] = [];
@@ -41,7 +41,7 @@ for (const file of files) {
     const status = statusBlock[1].trim();
     if (!STATUS_RE.test(status)) {
       errors.push(
-        `${file}: Status '${status}' is not allowed (must be Accepted, Deprecated, Superseded by NNNN, or Amended by NNNN)`,
+        `${file}: Status '${status}' is not allowed (must be Accepted, Deprecated, or Superseded by NNNN)`,
       );
     }
   }

--- a/scripts/validate-adrs.ts
+++ b/scripts/validate-adrs.ts
@@ -1,0 +1,65 @@
+// Validates docs/adr/ against ADR-0000's conventions: filename pattern,
+// sequential numbering, required Nygard sections, and allowed Status values.
+// `Proposed` is rejected — the PR review is the deliberation.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ADR_DIR = join(process.cwd(), "docs", "adr");
+const FILENAME_RE = /^(\d{4})-[a-z0-9]+(?:-[a-z0-9]+)*\.md$/;
+const STATUS_RE = /^(Accepted|Deprecated|Superseded by \d{4}|Amended by \d{4})$/;
+const REQUIRED_SECTIONS = ["Status", "Context", "Decision", "Consequences"];
+
+const errors: string[] = [];
+const numbers: number[] = [];
+
+const files = readdirSync(ADR_DIR)
+  .filter((name) => name.endsWith(".md") && name !== "README.md")
+  .sort();
+
+for (const file of files) {
+  const match = FILENAME_RE.exec(file);
+  if (!match) {
+    errors.push(`${file}: filename must match NNNN-kebab-case.md`);
+    continue;
+  }
+  numbers.push(Number(match[1]));
+
+  const content = readFileSync(join(ADR_DIR, file), "utf-8");
+
+  for (const section of REQUIRED_SECTIONS) {
+    const re = new RegExp(`^## ${section}\\s*$`, "m");
+    if (!re.test(content)) {
+      errors.push(`${file}: missing required '## ${section}' section`);
+    }
+  }
+
+  const statusBlock = /^## Status\s*\n+([^\n]+)/m.exec(content);
+  if (!statusBlock) {
+    errors.push(`${file}: could not parse Status block`);
+  } else {
+    const status = statusBlock[1].trim();
+    if (!STATUS_RE.test(status)) {
+      errors.push(
+        `${file}: Status '${status}' is not allowed (must be Accepted, Deprecated, Superseded by NNNN, or Amended by NNNN)`,
+      );
+    }
+  }
+}
+
+const sorted = [...numbers].sort((a, b) => a - b);
+for (let i = 0; i < sorted.length; i++) {
+  if (sorted[i] !== i) {
+    errors.push(
+      `ADR numbering must be sequential from 0000 with no gaps or duplicates; expected ${String(i).padStart(4, "0")} but found ${String(sorted[i]).padStart(4, "0")}`,
+    );
+    break;
+  }
+}
+
+if (errors.length > 0) {
+  for (const err of errors) console.error(`✗ ${err}`);
+  process.exit(1);
+}
+
+console.log(`✓ ${files.length} ADR(s) validated`);


### PR DESCRIPTION
## Summary

ADRs now block at pre-commit if Status is anything other than `Accepted`, `Deprecated`, or `Superseded by NNNN` — codifying merge-as-Accepted as the gate. Status set matches Nygard's original four minus `Proposed`. ADR-0000's policy paragraph and both existing ADRs update to match.

## Gotchas

ADR-0000's body changes alongside its Status: the original sentence "New ADRs land as Proposed. Maintainers promote on merge or review." would have contradicted the new policy. Sanity-check the new wording in the Decision section.

Skipped commit-time `lychee` on this branch (filed in #295 — local binary GLIBC mismatch); CI lychee runs normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)