### PR TITLE
build: approve esbuild and unrs-resolver build scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 packages:
   - "packages/*"
+onlyBuiltDependencies:
+  - esbuild
+  - unrs-resolver


### PR DESCRIPTION
## Summary

pnpm 11 promotes ignored build scripts from a warning to a hard install error (`ERR_PNPM_IGNORED_BUILDS`). Approving the two transitive deps with build scripts on the current lockfile (`esbuild`, `unrs-resolver`) keeps `pnpm install --frozen-lockfile` green and unblocks the pnpm 11 upgrade in #304 once Renovate rebases it.

## Verification

- Ran `pre-commit run --files pnpm-workspace.yaml` — all enabled hooks pass.
- Ran `pnpm install --frozen-lockfile` under the repo's pinned pnpm 10.33.4 — no regression.
- The pnpm 11 path is covered by #304's CI matrix once this lands and #304 is rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)