### PR TITLE
build: switch to allowBuilds map for pnpm 11

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 packages:
   - "packages/*"
-onlyBuiltDependencies:
-  - esbuild
-  - unrs-resolver
+allowBuilds:
+  esbuild: true
+  unrs-resolver: true


### PR DESCRIPTION
## Summary

pnpm 11 introduced `allowBuilds`, a per-package boolean map for build-script approval, and silently ignores the legacy `onlyBuiltDependencies` list that #307 added. The new field is required to unblock pnpm 11's install-time `ERR_PNPM_IGNORED_BUILDS` in #304 — once this lands, Renovate rebases #304 and the eight failing checks should clear.

## Gotchas

The legacy `onlyBuiltDependencies` is gone. Under the still-pinned pnpm 10.33.4, `allowBuilds` is an unknown field, so master will fall back to "ignored build scripts" (a warning, not an error) for `esbuild` and `unrs-resolver` until #304 lands. That's the same state master had before #307 — no regression versus pre-#307, just a transient gap to keep the diff coherent with the bump.

## Verification

Clean install (`rm -rf node_modules packages/*/node_modules` then `pnpm install --frozen-lockfile`) confirmed under both pinned versions:

- pnpm 10.33.4 — install succeeds, build scripts ignored with warning (expected).
- pnpm 11.1.1 — install succeeds, build scripts run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)