### PR TITLE
ci: switch pre-commit lychee hook to the system binary

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Setup Node.js + pnpm
         uses: ./.github/actions/setup-node-pnpm
 
+      - name: Install lychee
+        run: ./scripts/install-lychee.sh
+
       - name: Run
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,12 +85,17 @@ repos:
         types_or: [markdown, rst, plain-text]
         args: ["--config=.vale.ini", "--minAlertLevel=error"]
 
-  # Lychee link checker (auto-installs the binary)
-  - repo: https://github.com/lycheeverse/lychee
-    rev: lychee-v0.24.2
+  # Lychee link checker. Uses the system-installed binary (provisioned by
+  # scripts/install-lychee.sh in the devcontainer and CI) rather than the
+  # upstream hook's precompiled binary, which links against GLIBC 2.38 and
+  # fails to run on Debian 12 hosts shipping GLIBC 2.36. The pinned version
+  # lives in scripts/install-lychee.sh and is Renovate-tracked from there.
+  - repo: local
     hooks:
       - id: lychee
-        args: ["--config=lychee.toml", "--no-progress"]
+        name: lychee
+        entry: lychee --config=lychee.toml --no-progress
+        language: system
         types: [markdown]
 
   # Conventional Commits validation - runs at the commit-msg stage to reject

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,16 @@
     "enabled": true,
     "schedule": ["before 6pm on friday"]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the lychee pin in scripts/install-lychee.sh now that the pre-commit hook runs the system binary instead of an upstream-managed repo entry",
+      "managerFilePatterns": ["^scripts/install-lychee\\.sh$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?) extractVersion=(?<extractVersion>.+?)\\s+LYCHEE_VERSION=\"(?<currentValue>.+?)\""
+      ]
+    }
+  ],
   "packageRules": [
     {
       "description": "Group non-major npm updates in a single PR; majors land individually for review",

--- a/scripts/install-lychee.sh
+++ b/scripts/install-lychee.sh
@@ -10,9 +10,13 @@
 
 set -e
 
-LYCHEE_VERSION="v0.15.1"
-LYCHEE_ARCHIVE="lychee-${LYCHEE_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-LYCHEE_URL="https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VERSION}/${LYCHEE_ARCHIVE}"
+# Upstream tags releases as "lychee-vX.Y.Z" and ships assets without the
+# version in the filename. Renovate strips the prefix via extractVersion so
+# the bare semver lives in LYCHEE_VERSION here.
+# renovate: datasource=github-releases depName=lycheeverse/lychee extractVersion=^lychee-(?<version>v.+)$
+LYCHEE_VERSION="v0.24.2"
+LYCHEE_ARCHIVE="lychee-x86_64-unknown-linux-gnu.tar.gz"
+LYCHEE_URL="https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/${LYCHEE_ARCHIVE}"
 
 echo "🔗 Installing lychee link checker (${LYCHEE_VERSION})..."
 

--- a/scripts/install-lychee.sh
+++ b/scripts/install-lychee.sh
@@ -15,7 +15,10 @@ set -e
 # the bare semver lives in LYCHEE_VERSION here.
 # renovate: datasource=github-releases depName=lycheeverse/lychee extractVersion=^lychee-(?<version>v.+)$
 LYCHEE_VERSION="v0.24.2"
-LYCHEE_ARCHIVE="lychee-x86_64-unknown-linux-gnu.tar.gz"
+# Pull the statically linked musl build so the same binary runs on
+# ubuntu-latest CI runners and on Debian 12 devcontainers (whose GLIBC
+# 2.36 cannot satisfy the GNU build's GLIBC 2.38+ requirement).
+LYCHEE_ARCHIVE="lychee-x86_64-unknown-linux-musl.tar.gz"
 LYCHEE_URL="https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/${LYCHEE_ARCHIVE}"
 
 echo "🔗 Installing lychee link checker (${LYCHEE_VERSION})..."
@@ -29,7 +32,10 @@ echo "  📥 Downloading from ${LYCHEE_URL}..."
 curl -sSfL "${LYCHEE_URL}" -o "${TEMP_DIR}/${LYCHEE_ARCHIVE}"
 
 echo "  📦 Extracting archive..."
-tar -xzf "${TEMP_DIR}/${LYCHEE_ARCHIVE}" -C "${TEMP_DIR}"
+# Modern lychee tarballs wrap their contents in a target-named top-level
+# directory; strip it so the binary lands at ${TEMP_DIR}/lychee for the mv
+# below.
+tar -xzf "${TEMP_DIR}/${LYCHEE_ARCHIVE}" -C "${TEMP_DIR}" --strip-components=1
 
 # Install to appropriate location
 if [[ -n "${GITHUB_ACTIONS}" ]]; then


### PR DESCRIPTION
## Summary

Pre-commit now runs the system-installed lychee instead of the upstream hook's precompiled binary, so Debian 12 (GLIBC 2.36) devcontainers stop failing on every markdown-touching commit. CI installs lychee via the existing `scripts/install-lychee.sh` before pre-commit runs.

## Gotchas

The hot path is `scripts/install-lychee.sh`: I had to rewrite the URL construction because upstream's release tag scheme changed between v0.15.1 (the previous stale pin) and v0.24.2 (now). Tags now look like `lychee-v0.24.2` and the asset filename dropped the embedded version, hence the `lychee-${LYCHEE_VERSION}` prefix in `LYCHEE_URL` and the `extractVersion=^lychee-(?<version>v.+)$` hint for Renovate. Worth a sanity check that the Renovate customManager parses cleanly when the next release lands.

## Verification

- `pre-commit run lychee --files README.md` passed on a Debian 12 host with `lychee` on PATH; no new `~/.cache/pre-commit/repolychee*` entry was created.
- `pre-commit run --all-files` is green on the full tree.
- `curl -I` against `https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-x86_64-unknown-linux-gnu.tar.gz` returns a 302 (redirect to the asset blob), confirming the rewritten URL resolves.

Closes #295