### PR TITLE
ci: persist lychee cache across CI runs to tolerate transient 5xx

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,5 +28,17 @@ jobs:
       - name: Install lychee
         run: ./scripts/install-lychee.sh
 
+      # Persist lychee's URL→status cache across CI runs so unchanged links
+      # don't re-hit the network every PR. lychee's own max_cache_age (1d)
+      # still re-validates entries daily, so real link rot surfaces; the
+      # cache_exclude_status in lychee.toml keeps transient 5xx out.
+      - name: Cache lychee link-check results
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: .lycheecache
+          key: lychee-${{ hashFiles('scripts/install-lychee.sh', 'lychee.toml') }}-${{ github.run_id }}
+          restore-keys: |
+            lychee-${{ hashFiles('scripts/install-lychee.sh', 'lychee.toml') }}-
+
       - name: Run
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/lychee.toml
+++ b/lychee.toml
@@ -17,6 +17,15 @@ accept = [
 ]
 # Enable caching for faster repeated runs (default: false)
 cache = true
+# Never cache transient failures: rate-limits (429) and any 5xx upstream
+# error. Without this, a single GitHub 502 during a CI run would poison
+# the persisted cache and re-fail subsequent runs until max_cache_age (1d)
+# expired the entry.
+cache_exclude_status = "429, 500.."
+# Wait between retries of failed requests. Lychee defaults to 3 retries
+# at 1s, which proved too short to ride out GitHub 502 storms (see #288).
+# Bumped to 10s for ~30s of total retry window per link.
+retry_wait_time = 10
 # Filesystem paths to skip
 exclude_path = ["node_modules", "dist", "build"]
 # Exclude patterns (files/URLs to skip)


### PR DESCRIPTION
## Summary

PRs that don't touch markdown links no longer fail the `hooks` CI job when GitHub returns a transient 502, closing the most common single source of CI flake. Achieved by pairing a persisted lychee cache (so unchanged links don't re-hit the network each run) with a wider in-run retry window and an explicit cache-exclude for 5xx/429 so transient failures can't poison the persisted cache.

## Gotchas

Focus review on `lychee.toml`'s `cache_exclude_status = "429, 500.."` — that string format isn't obvious from the docs but matches lychee's own `lychee.example.toml`. Without it the persisted cache could lock in a transient 502 and re-fail every subsequent run until `max_cache_age` (1d) expired the entry. The cache key includes a hash of `scripts/install-lychee.sh` and `lychee.toml` so a lychee bump or config change auto-invalidates.

I evaluated all four candidates the issue listed; combining cache persistence with the retry-wait bump was the only pair that meets all three acceptance criteria — soft-accepting 5xx drops the link-rot signal, and a scheduled workflow slows feedback on real rot without solving the steady-state re-check problem.

## Verification

- Ran `lychee --config=lychee.toml --no-progress README.md` locally: 18 links checked, 11 OK, exit 0, `.lycheecache` produced with `URL,status,timestamp` entries.
- Ran `pre-commit run --files lychee.toml .github/workflows/pre-commit.yml`: all hooks pass.

Closes #288.