### PR TITLE
ci: lint workflows via actionlint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,6 @@ repos:
       - id: check-json
         exclude: '(\.devcontainer/.*\.json$|\.vscode/.*\.json$)' # DevContainer and VS Code files use JSONC (JSON with comments)
       - id: check-yaml
-        exclude: '^\.github/workflows/' # GitHub Actions YAML can have some special syntax
 
       # Other useful checks
       - id: check-executables-have-shebangs
@@ -66,7 +65,14 @@ repos:
     hooks:
       - id: yamllint
         args: ["-d", "relaxed"]
-        exclude: '^\.github/workflows/' # Skip GitHub Actions workflows
+
+  # GitHub Actions workflow linting. actionlint owns workflow YAML validation
+  # (schema, expression syntax, shellcheck integration); check-yaml and yamllint
+  # now cover the basic parse/style smells on the same files.
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
 
   # TOML formatting and linting with taplo
   - repo: https://github.com/ComPWA/taplo-pre-commit


### PR DESCRIPTION
## Summary

Pre-commit now schema-checks `.github/workflows/*.yml` locally via
`rhysd/actionlint`, so workflow mistakes surface before push instead of
on the failing CI run that motivated #256.

`check-yaml` and `yamllint` previously skipped the workflow directory on
the theory that GitHub Actions syntax was too special to parse — in
practice both parse it fine, so the exclusions are gone and the two
hooks now layer behind actionlint's schema and shellcheck checks.

## Verification

- `pre-commit run --files .github/workflows/*.yml` invokes actionlint
  and passes (acceptance criterion 1).
- `pre-commit run --all-files` passes end-to-end.

The Renovate criterion (acceptance criterion 2) is observable only
after merge, when the pre-commit manager picks up the new pinned
`rev`. `renovate.json` already has `pre-commit.enabled: true`, so no
config change needed.

Closes #256