### PR TITLE
ci: pin pnpm to 10.x to keep Node 20 CI green

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "private": true,
   "engines": {
     "node": ">=20.0.0",
-    "pnpm": ">=10.0.0"
+    "pnpm": ">=10.0.0 <11.0.0"
   },
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@10.34.1",
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@types/node": "24.12.4",

--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,11 @@
       "addLabels": ["npm"]
     },
     {
+      "description": "Hold pnpm on the 10.x line: pnpm 11.x requires Node >=22.13 and imports node:sqlite (Node >=22.5), which the CI matrix's lts/-2 Node 20 line cannot run",
+      "matchPackageNames": ["pnpm"],
+      "allowedVersions": "<11.0.0"
+    },
+    {
       "description": "Group all GitHub Actions updates in a single PR",
       "matchManagers": ["github-actions"],
       "groupName": "github actions",


### PR DESCRIPTION
## Summary

The `Test (core, Node lts/-2)` job is green again across the matrix. `lts/-2` resolves to Node 20, but pnpm 11.x declares `engines.node: >=22.13` and imports `node:sqlite` (a builtin only present from Node 22.5), so pnpm aborts before any test runs — leaving master and every open PR red, #318 included. Holding pnpm on the Node-20-compatible 10.x line (pin `packageManager` to pnpm@10.34.1, cap `engines.pnpm` at `<11.0.0`, plus a Renovate rule so it isn't bumped back) restores coverage of the full supported-LTS matrix.

This fixes the underlying cause shared with #318 rather than #318 alone: the pnpm 11.1.1 → 11.5.1 bump there was a red herring (both crash identically on Node 20). Once this merges, Renovate will rebase #318, drop the now-disallowed pnpm bump, and its remaining dependency updates should pass.

## Gotchas

The decision here is policy: keep Node 20 (EOL April 2026) on the strength of the deliberate `lts/-2` coverage comment in `ci.yml`, at the cost of freezing the package manager on pnpm 10.x. The alternative — dropping Node 20 and moving to pnpm 11.x — was considered and declined. The Renovate `allowedVersions: "<11.0.0"` rule and the `engines.pnpm` cap are what hold that line; revisit both if Node 20 is eventually dropped.

## Verification

Ran the exact failing CI command, `pnpm --filter @woodland-generators/core run test:coverage`, under Node 20.20.2 with pnpm 10.34.1 — 107 passed, 14 suites, no `node:sqlite` crash. Confirmed the lockfile is byte-identical under pnpm 10.34.1 (both lines use lockfileVersion 9.0), so CI's `--frozen-lockfile` install is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)