### PR TITLE
docs: move comma inside quotes in Foundry how-to

### DIFF
--- a/docs/how-to/verify-foundry-module-with-docker-compose.md
+++ b/docs/how-to/verify-foundry-module-with-docker-compose.md
@@ -15,7 +15,7 @@
    ```
 
    Set `FOUNDRY_RELEASE_URL` to a timed link from your Foundry account
-   (Purchased Software Licenses, OS set to "Node.js", timed URL button). It
+   (Purchased Software Licenses, OS set to "Node.js," timed URL button). It
    expires, so generate it just before starting the container. Later runs reuse
    the cached build and license from the `foundry-data` volume and need no
    `.env`.


### PR DESCRIPTION
## Summary

Vale's Microsoft.Quotes rule wants punctuation inside the closing quote
(American convention). The pinned Vale (3.14.2) misses the violation at
`verify-foundry-module-with-docker-compose.md:18`, but 3.15.x catches
it — so #341's bump fails CI on a flaw that already exists on master.
Fixing it here lets the rebased #341 land as a pure dependency change.

## Verification

- Ran the `vale` pre-commit hook locally; it now passes on the file.