### PR TITLE
chore: align repo config with main default branch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -6,9 +6,9 @@ name: Benchmarks
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
     # Skip bench on PRs that don't touch perf-relevant code.
     paths:
       - "packages/*/src/**"
@@ -26,7 +26,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   bench:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,16 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   test:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,16 +6,16 @@ name: Pre-commit
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,8 +76,7 @@ When working a numbered issue:
 ## Releases
 
 No automated release tooling is wired up right now. Both packages sit at `0.0.0`
-and nothing publishes from `master`. `CHANGELOG.md` is frozen as historical
-record of the pre-workspace era; don't append to it until a release process
-returns.
+and nothing publishes from `main`. `CHANGELOG.md` is frozen as historical record
+of the pre-workspace era; don't append to it until a release process returns.
 
 [conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/

--- a/packages/foundry-module/module.json
+++ b/packages/foundry-module/module.json
@@ -15,6 +15,6 @@
   ],
   "esmodules": ["dist/module.js"],
   "url": "https://github.com/alunduil/woodland-generators",
-  "readme": "https://github.com/alunduil/woodland-generators/blob/master/packages/foundry-module/README.md",
+  "readme": "https://github.com/alunduil/woodland-generators/blob/main/packages/foundry-module/README.md",
   "bugs": "https://github.com/alunduil/woodland-generators/issues"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
-  "baseBranchPatterns": ["master"],
+  "baseBranchPatterns": ["main"],
   "schedule": ["before 6pm on friday"],
   "timezone": "Europe/London",
   "labels": ["dependencies", "automated"],


### PR DESCRIPTION
## Summary

Retarget every config that pins `master` to `main` so the first push after the infra-side rename (alunduil/alunduil-infrastructure#24) fires the renamed workflows immediately. Covers the `ci`/`bench`/`pre-commit` branch triggers and concurrency guards, Renovate's `baseBranchPatterns`, plus two stray references (the foundry module's readme URL and CLAUDE.md's release note).

Closes #262

## Gotchas

- Merge this **before** the infra rename — the issue sequences it that way so `main` already carries the renamed triggers when the default flips.
- The issue's scope named `release-please.yml`, but that workflow was dropped in #315; only `ci`/`bench`/`pre-commit` carry branch pins now.
- module.json and CLAUDE.md are updated beyond the issue's explicit Scope bullets so acceptance criterion 3's grep comes back clean. The remaining `master` hits are `.vale/styles/*` dictionary entries and a generated formatjs deprecation URL in `pnpm-lock.yaml`, neither a project-config pin.

## Verification

- `pre-commit run --files` green on all six changed files (prettier reflowed the CLAUDE.md paragraph after the shorter word shifted the wrap; re-staged).
- `grep -rln 'master' --exclude-dir=node_modules --exclude-dir=.git --exclude=CHANGELOG.md` returns only the expected `.vale/styles/*` and `pnpm-lock.yaml` leftovers.