### PR TITLE
feat(foundry-module): bundle a manifest-declared stylesheet

### DIFF
--- a/packages/foundry-module/esbuild.config.mjs
+++ b/packages/foundry-module/esbuild.config.mjs
@@ -5,12 +5,13 @@
 import { build, context } from "esbuild";
 
 const config = {
-  entryPoints: ["src/module.ts"],
+  entryPoints: ["src/module.ts", "src/styles/module.css"],
   bundle: true,
   format: "esm",
   target: "es2022",
   platform: "browser",
-  outfile: "dist/module.js",
+  outdir: "dist",
+  outbase: "src",
   sourcemap: true,
   logLevel: "info",
 };

--- a/packages/foundry-module/module.json
+++ b/packages/foundry-module/module.json
@@ -14,6 +14,7 @@
     }
   ],
   "esmodules": ["dist/module.js"],
+  "styles": ["dist/styles/module.css"],
   "url": "https://github.com/alunduil/woodland-generators",
   "readme": "https://github.com/alunduil/woodland-generators/blob/master/packages/foundry-module/README.md",
   "bugs": "https://github.com/alunduil/woodland-generators/issues"

--- a/packages/foundry-module/src/styles/module.css
+++ b/packages/foundry-module/src/styles/module.css
@@ -1,0 +1,4 @@
+/* SPDX-FileCopyrightText: 2025-2026 Alex Brandt
+ *
+ * SPDX-License-Identifier: MIT
+ */


### PR DESCRIPTION
## Summary

The Foundry module now ships a module-scoped stylesheet: `module.json` declares
it under `styles` and the build emits it to `dist/`. Standing the styling
pipeline up once here keeps the upcoming generator menu and dialogs (#225, #227,
#229) from each inventing their own.

Closes #333

## Gotchas

- esbuild rejects multiple entry points paired with `outfile`, so the config
  moves to `outdir`/`outbase: "src"`. That keeps `dist/module.js` at its
  existing path (unchanged in `esmodules`) while emitting the new entry to
  `dist/styles/module.css`.
- `src/styles/module.css` is intentionally header-only for now — the pipeline
  is the deliverable; the feature PRs fill in the rules.

## Verification

- `pnpm -r build` emits both `dist/module.js` and `dist/styles/module.css`.
- `pre-commit run --all-files` passes (typecheck, eslint, prettier, knip,
  reuse).