### PR TITLE
feat(foundry-module): localize strings through Foundry i18n

### DIFF
--- a/packages/foundry-module/README.md
+++ b/packages/foundry-module/README.md
@@ -2,8 +2,8 @@
 
 The Foundry VTT integration package for [Woodland Generators](../../README.md).
 Built output is an ESM bundle that Foundry loads as a module. The loaded module
-registers under the ID `woodland-generators` and logs an init-hook heartbeat to
-the browser console.
+registers under the ID `woodland-generators` and logs a localized heartbeat to
+the browser console once Foundry initializes its localization.
 
 ## Build
 

--- a/packages/foundry-module/languages/en.json
+++ b/packages/foundry-module/languages/en.json
@@ -1,0 +1,3 @@
+{
+  "WOODLAND-GENERATORS.Initialized": "initialized"
+}

--- a/packages/foundry-module/module.json
+++ b/packages/foundry-module/module.json
@@ -14,6 +14,13 @@
     }
   ],
   "esmodules": ["dist/module.js"],
+  "languages": [
+    {
+      "lang": "en",
+      "name": "English",
+      "path": "languages/en.json"
+    }
+  ],
   "url": "https://github.com/alunduil/woodland-generators",
   "readme": "https://github.com/alunduil/woodland-generators/blob/master/packages/foundry-module/README.md",
   "bugs": "https://github.com/alunduil/woodland-generators/issues"

--- a/packages/foundry-module/package.json
+++ b/packages/foundry-module/package.json
@@ -7,6 +7,7 @@
   "private": true,
   "files": [
     "dist/",
+    "languages/",
     "module.json",
     "README.md"
   ],

--- a/packages/foundry-module/src/module.ts
+++ b/packages/foundry-module/src/module.ts
@@ -2,9 +2,13 @@
 //
 // SPDX-License-Identifier: MIT
 
-/* global Hooks */
+/* global Hooks, game */
 const MODULE_ID = "woodland-generators";
 
-Hooks.once("init", () => {
-  console.log(`${MODULE_ID} | initialized`);
+// i18nInit, not init: the translation catalog loads just before this hook, so
+// localize resolves the key rather than echoing it back.
+Hooks.once("i18nInit", () => {
+  if (game.i18n) {
+    console.log(`${MODULE_ID} | ${game.i18n.localize("WOODLAND-GENERATORS.Initialized")}`);
+  }
 });


### PR DESCRIPTION
## Summary

The Foundry module now ships a `languages/en.json` catalog and resolves its
startup heartbeat through `game.i18n`, so Foundry can localize the module and
translators have a catalog to translate against — where before the only
user-facing string was hardcoded and nothing was localizable.

Closes #332

## Gotchas

- The heartbeat moved from the `init` hook to `i18nInit`. The translation
  catalog loads just before `i18nInit`, so localizing in `init` would echo the
  raw key back instead of the translated string.
- `game.i18n` is typed as possibly-undefined in the ambient game type (the hook
  doesn't narrow the global), so the log is guarded with `if (game.i18n)` rather
  than a non-null assertion — it degrades to no-op if the assumption ever breaks.

## Verification

- `pre-commit run` over the changed files: typecheck, eslint, prettier, reuse,
  knip all pass.
- Built the module and confirmed the bundle carries the `i18nInit` hook and the
  `localize("WOODLAND-GENERATORS.Initialized")` call.
- Did not run a live Foundry load; the documented docker-compose how-to covers
  that if a maintainer wants end-to-end confirmation.