### PR TITLE
chore: track main instead of master default branch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -6,9 +6,9 @@ name: Benchmarks
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
     # Skip bench on PRs that don't touch perf-relevant code.
     paths:
       - "packages/*/src/**"
@@ -26,7 +26,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   bench:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,16 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   test:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,16 +6,16 @@ name: Pre-commit
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,8 +76,7 @@ When working a numbered issue:
 ## Releases
 
 No automated release tooling is wired up right now. Both packages sit at `0.0.0`
-and nothing publishes from `master`. `CHANGELOG.md` is frozen as historical
-record of the pre-workspace era; don't append to it until a release process
-returns.
+and nothing publishes from `main`. `CHANGELOG.md` is frozen as historical record
+of the pre-workspace era; don't append to it until a release process returns.
 
 [conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/

--- a/packages/foundry-module/module.json
+++ b/packages/foundry-module/module.json
@@ -23,6 +23,6 @@
     }
   ],
   "url": "https://github.com/alunduil/woodland-generators",
-  "readme": "https://github.com/alunduil/woodland-generators/blob/master/packages/foundry-module/README.md",
+  "readme": "https://github.com/alunduil/woodland-generators/blob/main/packages/foundry-module/README.md",
   "bugs": "https://github.com/alunduil/woodland-generators/issues"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
-  "baseBranchPatterns": ["master"],
+  "baseBranchPatterns": ["main"],
   "schedule": ["before 6pm on friday"],
   "timezone": "Europe/London",
   "labels": ["dependencies", "automated"],


### PR DESCRIPTION
## Summary

Point every config that pins the default branch at the post-rename `main`,
so the first push to `main` fires the renamed CI/bench/pre-commit workflows
and Renovate opens bumps against the right base ref. Covers the workflow
`branches:` triggers and `refs/heads/master` concurrency guards,
`renovate.json`'s `baseBranchPatterns`, the stale `blob/master` readme URL
in the Foundry manifest, and the `master` reference in CLAUDE.md's Releases
note.

The rename itself, the Terraform `default_branch` flip, and the
branch-protection re-apply are infra-side (alunduil/alunduil-infrastructure#24).

Closes #262

## Gotchas

- Sequencing: this must merge *before* the rename in
  alunduil/alunduil-infrastructure#24. Until then the triggers point at a
  branch that doesn't exist yet, so CI won't run on pushes to the (still
  `master`) default. Land it when the PR queue is small.
- The issue listed `release-please.yml`, but that workflow was removed since
  filing — nothing to change there. Remaining `master` hits are Vale
  dictionaries and a third-party formatjs URL in the lockfile, both expected.

## Verification

- `grep -rln 'master' --exclude-dir=node_modules --exclude-dir=.git --exclude=CHANGELOG.md`
  returns no project-config hits.
- `pre-commit run --files ...` passes on all changed files (actionlint,
  prettier, markdownlint, check-json included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ksp8r8xWST8ECrBMrkpgyR