### PR TITLE
fix: restore Renovate updates and harden the config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -122,6 +122,18 @@ repos:
         language: system
         types: [markdown]
 
+  # Renovate config validation. --strict also fails on configs that merely need
+  # migration (e.g. fileMatch -> managerFilePatterns), not just outright errors;
+  # --no-global stops the validator treating renovate.json as self-hosted global
+  # config, which misreports repo-only fields. Neither is an upstream default.
+  # Remote presets are not resolved, so a missing `extends` target still only
+  # surfaces as a Repository Problem on the next Renovate run.
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 44.2.1
+    hooks:
+      - id: renovate-config-validator
+        args: [--strict, --no-global]
+
   # Conventional Commits validation - runs at the commit-msg stage to reject
   # non-conventional commit subjects. Requires `--hook-type commit-msg` at
   # install time.

--- a/renovate.json
+++ b/renovate.json
@@ -39,17 +39,7 @@
       "minimumReleaseAge": null
     },
     {
-      "description": "Group non-major npm updates in a single PR; majors land individually for review",
       "matchManagers": ["npm"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "groupName": "npm dependencies",
-      "groupSlug": "npm",
-      "addLabels": ["npm"]
-    },
-    {
-      "description": "Label major npm updates so they are easy to spot",
-      "matchManagers": ["npm"],
-      "matchUpdateTypes": ["major"],
       "addLabels": ["npm"]
     },
     {
@@ -58,24 +48,15 @@
       "allowedVersions": "<11.0.0"
     },
     {
-      "description": "Group all GitHub Actions updates in a single PR",
       "matchManagers": ["github-actions"],
-      "groupName": "github actions",
-      "groupSlug": "github-actions",
       "addLabels": ["actions"]
     },
     {
-      "description": "Group all Docker updates in a single PR",
       "matchManagers": ["dockerfile", "docker-compose"],
-      "groupName": "docker dependencies",
-      "groupSlug": "docker",
       "addLabels": ["docker"]
     },
     {
-      "description": "Group all DevContainer updates in a single PR",
       "matchManagers": ["devcontainer"],
-      "groupName": "devcontainer dependencies",
-      "groupSlug": "devcontainer",
       "addLabels": ["devcontainer"]
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,29 +1,43 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
-  "baseBranchPatterns": ["master"],
-  "schedule": ["before 6pm on friday"],
+  "extends": [
+    "config:best-practices",
+    "security:openssf-scorecard",
+    "customManagers:githubActionsVersions"
+  ],
   "timezone": "Europe/London",
   "labels": ["dependencies", "automated"],
   "reviewers": ["alunduil"],
+  "minimumReleaseAge": "3 days",
+  "osvVulnerabilityAlerts": true,
   "pre-commit": {
     "enabled": true
-  },
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["before 6pm on friday"]
   },
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Track the lychee pin in scripts/install-lychee.sh now that the pre-commit hook runs the system binary instead of an upstream-managed repo entry",
-      "managerFilePatterns": ["^scripts/install-lychee\\.sh$"],
+      "description": "Read `# renovate:` annotations above shell `*_VERSION=` pins so a new pin needs an annotation rather than a manager of its own",
+      "managerFilePatterns": ["scripts/*"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?) extractVersion=(?<extractVersion>.+?)\\s+LYCHEE_VERSION=\"(?<currentValue>.+?)\""
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: packageName=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION=\"(?<currentValue>.+?)\""
       ]
     }
   ],
   "packageRules": [
+    {
+      "description": "Exempt update types that cannot carry a release timestamp from the bake period; without this they stall forever on a pending stability check and no PR is ever opened",
+      "matchUpdateTypes": [
+        "pin",
+        "pinDigest",
+        "digest",
+        "lockFileMaintenance",
+        "lockfileUpdate",
+        "rollback",
+        "bump",
+        "replacement"
+      ],
+      "minimumReleaseAge": null
+    },
     {
       "description": "Group non-major npm updates in a single PR; majors land individually for review",
       "matchManagers": ["npm"],
@@ -52,7 +66,7 @@
     },
     {
       "description": "Group all Docker updates in a single PR",
-      "matchManagers": ["dockerfile"],
+      "matchManagers": ["dockerfile", "docker-compose"],
       "groupName": "docker dependencies",
       "groupSlug": "docker",
       "addLabels": ["docker"]


### PR DESCRIPTION
## Summary

Renovate has opened no PRs here since the default branch was renamed:
`baseBranchPatterns` still pinned `master`, which no longer exists, so it
skipped the repository entirely and dashboard #150 detected zero dependencies.
The field is deleted rather than repointed at `main` — Renovate auto-detects the
default branch, and hard-coding it is what let the rename break silently.

With updates flowing again, the config moves to the shared baseline: bake every
datasource for three days rather than npm alone, widen alerts to OSV, extend
`security:openssf-scorecard` and `customManagers:githubActionsVersions`, and
validate `renovate.json` from pre-commit so the next mistake fails at commit
time.

Closes #395
Closes #349

## Gotchas

- The `packageRules` carve-out is what makes `minimumReleaseAge` safe, not
  decoration. Eight update types can't carry a release timestamp —
  `lockFileMaintenance`, `digest` and `pinDigest` among them, all in scope via
  `config:best-practices` — and with `minimumReleaseAgeBehaviour:
  timestamp-required` and `internalChecksFilter: strict` as defaults they'd wait
  forever on a check that never passes. No PR, no red X, just silence.
- Per-manager grouping and the Friday schedules are gone, so expect more,
  smaller PRs arriving as they come. `config:recommended` still groups monorepo
  packages that must move in lockstep. Lock file maintenance reverts to the
  weekly Monday slot.
- The old custom manager was inert: `managerFilePatterns` parses a bare string as
  a minimatch glob, so the `^` and `$` in `^scripts/install-lychee\.sh$` were
  literal characters matching no path. Its replacement reads the `# renovate:`
  annotation above any shell `*_VERSION=` pin, so the next pin needs an
  annotation rather than a manager of its own.
- The docker rule matched `dockerfile` only, and there is no Dockerfile. The one
  Docker dependency is `felddy/foundryvtt` in `docker-compose.yml`, owned by the
  separate `docker-compose` manager — which is why #388 landed unlabelled.
- Still outstanding: `master` in the `branches:` triggers and
  `refs/heads/master` concurrency guards of `ci.yml`, `bench.yml` and
  `pre-commit.yml`, plus a `blob/master` URL in `module.json`. #262 tracks it;
  #385 covered exactly this and was closed unmerged.

## Verification

Ran Renovate against the working tree on the old and new config
(`renovate --platform=local --dry-run=extract`, using the binary the new
validator hook installs):

- New config extracts 74 dependencies across six managers — `npm`,
  `github-actions`, `pre-commit`, `devcontainer`, `docker-compose`, `regex`. Old
  config: 73 and no `regex` manager at all. The one-dep delta is the lychee pin,
  confirming the old pattern was inert and the replacement works
  (`depName=lycheeverse/lychee`, `currentValue=v0.24.2`,
  `extractVersion=^lychee-(?<version>v.+)$`). Unchanged after the grouping rules
  came out.
- `pre-commit run` passes, including `renovate-config-validator --strict
  --no-global`.
- `security:openssf-scorecard`, `customManagers:githubActionsVersions` and the
  `docker-compose` manager name checked against Renovate's source, not the docs
  summary.
- Not provable pre-merge: the base-branch fix only takes effect once the config
  is on `main`, since Renovate reads the default branch. #395's acceptance
  criteria cover it — dashboard #150 should clear its Repository Problem and
  list detected dependencies on the next run.