### PR TITLE
docs: document the local Foundry install and iterate loop

### DIFF
--- a/docs/how-to/install-the-foundry-module-into-a-local-foundry.md
+++ b/docs/how-to/install-the-foundry-module-into-a-local-foundry.md
@@ -23,7 +23,7 @@
    $env:FOUNDRY_USER_DATA = "$env:LOCALAPPDATA\FoundryVTT"
    ```
 
-   If you start Foundry with `--dataPath`, or changed **User Data Path** in the
+   If you launch Foundry with `--dataPath` or set **User Data Path** in the
    setup screen, use that directory instead.
 
 2. Build the module bundle:
@@ -38,10 +38,8 @@
    pnpm --filter @woodland-generators/foundry-module install:dev
    ```
 
-   The command prints the link it created, and re-running it replaces the link
-   rather than nesting a second one. It exits without changing anything when
-   `Data/modules/woodland-generators` is a real directory; remove that directory
-   first.
+   Re-running replaces the link. The command exits without changing anything
+   when `Data/modules/woodland-generators` is a real directory; remove it first.
 
    On Windows, turn on Developer Mode or run the shell as Administrator.
    Creating a directory symlink fails with `EPERM` otherwise.
@@ -60,8 +58,8 @@
    pnpm --filter @woodland-generators/foundry-module build:watch
    ```
 
-2. Hard-reload the browser tab running the world to pick up the rebuilt bundle:
-   `Ctrl+Shift+R`, or `Cmd+Shift+R` on macOS.
+2. Hard-reload the browser tab running the world: `Ctrl+Shift+R`, or
+   `Cmd+Shift+R` on macOS.
 
 ## Remove the link
 

--- a/docs/how-to/install-the-foundry-module-into-a-local-foundry.md
+++ b/docs/how-to/install-the-foundry-module-into-a-local-foundry.md
@@ -2,7 +2,9 @@
 
 ## Prerequisites
 
-- Foundry VTT installed on the host.
+- Foundry VTT installed on the host. Without one, follow
+  [Verify with `docker compose`](verify-foundry-module-with-docker-compose.md)
+  instead.
 - The repository cloned, with `corepack enable` and `pnpm install` already run.
 
 ## Steps
@@ -66,6 +68,3 @@
 ```bash
 rm "$FOUNDRY_USER_DATA/Data/modules/woodland-generators"
 ```
-
-To verify the module without a host Foundry install, see
-[Verify with `docker compose`](verify-foundry-module-with-docker-compose.md).

--- a/docs/how-to/install-the-foundry-module-into-a-local-foundry.md
+++ b/docs/how-to/install-the-foundry-module-into-a-local-foundry.md
@@ -1,0 +1,71 @@
+# How to install the Foundry module into a local Foundry
+
+## Prerequisites
+
+- Foundry VTT installed on the host.
+- The repository cloned, with `corepack enable` and `pnpm install` already run.
+
+## Steps
+
+1. Point `FOUNDRY_USER_DATA` at your Foundry user data directory, the parent of
+   `Data/`, `Config/`, and `Logs/`:
+
+   ```bash
+   export FOUNDRY_USER_DATA=~/.local/share/FoundryVTT                  # Linux
+   export FOUNDRY_USER_DATA=~/Library/Application\ Support/FoundryVTT  # macOS
+   ```
+
+   On Windows:
+
+   ```powershell
+   $env:FOUNDRY_USER_DATA = "$env:LOCALAPPDATA\FoundryVTT"
+   ```
+
+   If you start Foundry with `--dataPath`, or changed **User Data Path** in the
+   setup screen, use that directory instead.
+
+2. Build the module bundle:
+
+   ```bash
+   pnpm --filter @woodland-generators/foundry-module build
+   ```
+
+3. Link the package into Foundry's modules directory:
+
+   ```bash
+   pnpm --filter @woodland-generators/foundry-module install:dev
+   ```
+
+   The command prints the link it created, and re-running it replaces the link
+   rather than nesting a second one. It exits without changing anything when
+   `Data/modules/woodland-generators` is a real directory; remove that directory
+   first.
+
+   On Windows, turn on Developer Mode or run the shell as Administrator.
+   Creating a directory symlink fails with `EPERM` otherwise.
+
+4. Start Foundry, open or create a world, and enable **Woodland Generators**
+   under _Manage Modules_.
+
+5. Open the browser console. The line `woodland-generators | initialized` on
+   world load confirms the module loaded.
+
+## Iterate on a change
+
+1. Rebuild on every save:
+
+   ```bash
+   pnpm --filter @woodland-generators/foundry-module build:watch
+   ```
+
+2. Hard-reload the browser tab running the world to pick up the rebuilt bundle:
+   `Ctrl+Shift+R`, or `Cmd+Shift+R` on macOS.
+
+## Remove the link
+
+```bash
+rm "$FOUNDRY_USER_DATA/Data/modules/woodland-generators"
+```
+
+To verify the module without a host Foundry install, see
+[Verify with `docker compose`](verify-foundry-module-with-docker-compose.md).

--- a/packages/foundry-module/README.md
+++ b/packages/foundry-module/README.md
@@ -17,8 +17,8 @@ entry.
 ## Verify it loads in Foundry
 
 With a host Foundry install:
-[Install into a local Foundry](../../docs/how-to/install-the-foundry-module-into-a-local-foundry.md),
-which also covers the watch-and-reload loop for iterating on a change.
+[Install into a local Foundry](../../docs/how-to/install-the-foundry-module-into-a-local-foundry.md).
+It also covers the watch-and-reload loop.
 
 Without one:
 [Verify with `docker compose`](../../docs/how-to/verify-foundry-module-with-docker-compose.md).

--- a/packages/foundry-module/README.md
+++ b/packages/foundry-module/README.md
@@ -16,7 +16,11 @@ entry.
 
 ## Verify it loads in Foundry
 
-Without a host Foundry install:
+With a host Foundry install:
+[Install into a local Foundry](../../docs/how-to/install-the-foundry-module-into-a-local-foundry.md),
+which also covers the watch-and-reload loop for iterating on a change.
+
+Without one:
 [Verify with `docker compose`](../../docs/how-to/verify-foundry-module-with-docker-compose.md).
 
 ## See also


### PR DESCRIPTION
## Summary

Documents the existing `install:dev` symlink script and `build:watch` loop, so a
contributor with a Foundry license gets from clone to a loaded module without
reading `package.json`. No code changed — the tooling shipped in #293 and #380;
only the documentation was missing.

Closes #226

## Gotchas

- Lands in `docs/how-to/` rather than the package README or `CONTRIBUTING.md`
  the issue's scope named, matching the repo-root Diátaxis layout. Whether the
  package README should index it at all is now #444.
- No `pnpm dev` script despite the issue's scope bullet: `build:watch` already
  watches and rebuilds.
- Steps 4 and 5 were not run against a real Foundry — no host install here. The
  `woodland-generators | initialized` string comes from `src/module.ts` and
  `languages/en.json`.
- No CI will run on this pull request: the Pre-commit workflow still triggers on
  `master` (#369).

## Verification

- Ran `install:dev` against a throwaway `FOUNDRY_USER_DATA`: it created the
  symlink, re-ran idempotently, refused to overwrite a real directory, and
  printed the platform paths when the variable was unset — every behaviour the
  how-to claims. `esbuild --watch` starts and rebuilds.
- `pre-commit run --all-files` green apart from the pre-existing `eslint` break
  (#441).