### PR TITLE
docs: rewrite CONTRIBUTING for the pnpm workspace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contributing to Woodland Generators
 
-Thank you for your interest in contributing! This CLI tool generates resources
-for Root: The Tabletop RPG.
+Thank you for your interest in contributing! Woodland Generators is a pnpm
+workspace of TypeScript packages that generate resources for Root: The Tabletop
+RPG.
 
 These guidelines help maintainers review your work. Following them shows respect
 for their time.
@@ -11,21 +12,100 @@ for their time.
 The project welcomes help that improves the tool's usefulness for Root RPG
 players:
 
-- **New generators** (NPCs, settlements, adventures)
-- **Output format improvements** (better PDF files, new formats)
+- **New generators** (NPCs, clearings, adventures)
+- **Foundry VTT integration** - surfacing generators inside a live world
 - **Bug fixes** and **performance improvements**
 - **Doc updates** and **examples**
 
+## Your first contribution
+
+Start with an issue labeled [good first issue][good-first-issue] or [help
+wanted][help-wanted]. Both filters list work that's ready to pick up without
+deep context on the codebase.
+
+Typos and formatting fixes need no issue at all - open a pull request directly.
+
+## Project layout
+
+Two packages live under `packages/`:
+
+- **`@woodland-generators/core`** - the generator algorithms. No user interface,
+  no input or output beyond logging. Most generator work lands here.
+- **`@woodland-generators/foundry-module`** - a Foundry VTT module that loads
+  core into a live world.
+
+Repository-wide docs sit in `docs/`, organized by
+[Diátaxis](https://diataxis.fr): how-to guides in `docs/how-to/`, architecture
+decisions in `docs/adr/`.
+
 ## Ground rules
 
-- **TypeScript with strict typing** - Type safety stays important
+- **TypeScript with strict typing** - type safety stays important
 - **Use pnpm** - the repository runs as a pnpm workspace; npm and yarn won't
   produce a working install. Run `corepack enable` once on Node 20 or newer; the
   pinned pnpm version comes from `package.json#packageManager`.
-- **Run checks** before submitting: `pre-commit run --all-files`
-- **Test your changes** with `pnpm run cli`
+- **Run the checks** before submitting - see [Checks](#checks) below
 - **Keep PRs focused** - one feature or fix per PR
 - **Stay patient** - reviews may take a few days
+
+## Quick start
+
+1. **Install dependencies**:
+
+   ```bash
+   corepack enable
+   pnpm install
+   ```
+
+2. **Build both packages**:
+
+   ```bash
+   pnpm run build
+   ```
+
+3. **Run the test suite**:
+
+   ```bash
+   pnpm test
+   ```
+
+4. **Development workflow** - rebuild and retest as you edit:
+
+   ```bash
+   pnpm --filter @woodland-generators/core build:watch
+   pnpm run test:watch
+   ```
+
+   `build:watch` is a per-package script, so it needs the `--filter` flag. The
+   root package has no `build:watch`.
+
+The repository also ships a [devcontainer](.devcontainer/devcontainer.json) with
+Node, pnpm, `pre-commit`, `shellcheck`, and Vale preinstalled. Open the
+repository in a supporting editor to skip the local tool setup.
+
+## Checks
+
+Two sensors gate a change, and you need both - `pre-commit` doesn't run the
+tests:
+
+```bash
+pre-commit run --all-files   # formatting, lint, types, prose, links
+pnpm test                    # Jest suite
+```
+
+`pre-commit run --all-files` covers Prettier, ESLint, `tsc --noEmit`, `knip`,
+`markdownlint`, `yamllint`, `actionlint`, `shellcheck`, REUSE licensing, Vale
+prose, and a link check. Many of those hooks fix files in place, so re-stage
+anything they touch.
+
+The authoritative hook list lives in `.pre-commit-config.yaml`.
+
+## Tests
+
+Test files mirror the module under test within each package. Tests for
+`packages/core/src/generators/name.ts` belong at
+`packages/core/test/generators/name.test.ts`. Don't split tests by feature or
+scenario.
 
 ## Commit messages
 
@@ -49,31 +129,9 @@ Examples:
 
 ```text
 feat: add character demeanor generation
-fix(cli): respect --seed flag in name generation
+fix(core): respect the seed argument in name generation
 chore(deps): bump typescript to 5.9.3
 ```
-
-## Quick start
-
-1. **Install dependencies**:
-
-   ```bash
-   corepack enable
-   pnpm install
-   ```
-
-2. **Test the CLI**:
-
-   ```bash
-   pnpm run cli -- character --help
-   ```
-
-3. **Development workflow**:
-
-   ```bash
-   pnpm run build:watch         # Watch mode dev
-   pre-commit run --all-files   # Check everything (auto-fixes)
-   ```
 
 ## How to submit changes
 
@@ -82,21 +140,41 @@ chore(deps): bump typescript to 5.9.3
 1. **Open an issue first** to discuss the approach
 2. Fork the repository and create a feature branch
 3. Make your changes following the code standards
-4. Run `pre-commit run --all-files` to check everything works
+4. Run the [checks](#checks)
 5. Submit a pull request with a clear description
 
 ### For small fixes (typos, formatting)
 
 - Feel free to submit directly without opening an issue first
 
+## Architecture decisions
+
+Changes that set technical direction get an Architecture Decision Record in
+`docs/adr/`. [ADR-0000](docs/adr/0000-record-architecture-decisions.md) explains
+the convention and doubles as the template. The `validate-adrs` hook checks
+filename pattern, sequential numbering, the required Nygard sections, and the
+allowed status values.
+
+## Working on the Foundry module
+
+Two how-to guides cover the module development loop:
+
+- [Install the module into a local Foundry][foundry-install] - link the built
+  bundle into your own Foundry user data directory and iterate on it.
+- [Verify with Docker Compose][foundry-docker] - for contributors without a
+  Foundry install on the host.
+
 ## How to report bugs or suggest features
 
-- **Bugs**: Use the [bug report template][bug-template] and include what command
-  you ran, what you expected, what happened, and your OS/Node.js version
+- **Bugs**: Use the [bug report template][bug-template] and include the steps to
+  reproduce, what you expected, what happened, and your environment
 - **Feature ideas**: Use the [feature request template][feature-template] and
-  tell what you want to build, why users need it, and how it works
-- **Questions and chat**: Use [GitHub Discussions][discussions] for general
-  questions, ideas, or community chat
+  tell what you want to accomplish, what you do today, and how it should work
+- **Planned work**: Maintainers use the [work item template][work-item-template]
+  for work that's broken down and ready to implement
+- **Questions and chat**: Use GitHub Discussions - [Q&A][discussions-qa] for
+  help requests, [Ideas][discussions-ideas] to float a feature before filing a
+  request, and [General][discussions-general] for anything else
 
 ## Code review process
 
@@ -106,8 +184,22 @@ chore(deps): bump typescript to 5.9.3
 - Once approved, maintainers will merge your PR
 
 [bug-template]:
-  https://github.com/alunduil/woodland-generators/issues/new?template=bug_report.yml
+  https://github.com/alunduil/woodland-generators/issues/new?template=bug-report.yml
 [conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
-[discussions]: https://github.com/alunduil/woodland-generators/discussions
+[discussions-general]:
+  https://github.com/alunduil/woodland-generators/discussions/categories/general
+[discussions-ideas]:
+  https://github.com/alunduil/woodland-generators/discussions/categories/ideas
+[discussions-qa]:
+  https://github.com/alunduil/woodland-generators/discussions/categories/q-a
 [feature-template]:
-  https://github.com/alunduil/woodland-generators/issues/new?template=feature_request.yml
+  https://github.com/alunduil/woodland-generators/issues/new?template=feature-request.yml
+[foundry-docker]: docs/how-to/verify-foundry-module-with-docker-compose.md
+[foundry-install]:
+  docs/how-to/install-the-foundry-module-into-a-local-foundry.md
+[good-first-issue]:
+  https://github.com/alunduil/woodland-generators/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+[help-wanted]:
+  https://github.com/alunduil/woodland-generators/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
+[work-item-template]:
+  https://github.com/alunduil/woodland-generators/issues/new?template=work-item.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,7 @@ Thank you for your interest in contributing! Woodland Generators is a pnpm
 workspace of TypeScript packages that generate resources for Root: The Tabletop
 RPG.
 
-These guidelines help maintainers review your work. Following them shows respect
-for their time.
+These guidelines help get your work reviewed quickly.
 
 ## What you can contribute
 
@@ -41,13 +40,12 @@ decisions in `docs/adr/`.
 
 ## Ground rules
 
-- **TypeScript with strict typing** - type safety stays important
 - **Use pnpm** - the repository runs as a pnpm workspace; npm and yarn won't
   produce a working install. Run `corepack enable` once on Node 20 or newer; the
   pinned pnpm version comes from `package.json#packageManager`.
+- **Keep strict typing** - `tsc --noEmit` runs as a check and has to pass
 - **Run the checks** before submitting - see [Checks](#checks) below
 - **Keep PRs focused** - one feature or fix per PR
-- **Stay patient** - reviews may take a few days
 
 ## Quick start
 
@@ -77,17 +75,13 @@ decisions in `docs/adr/`.
    pnpm run test:watch
    ```
 
-   `build:watch` is a per-package script, so it needs the `--filter` flag. The
-   root package has no `build:watch`.
-
 The repository also ships a [devcontainer](.devcontainer/devcontainer.json) with
 Node, pnpm, `pre-commit`, `shellcheck`, and Vale preinstalled. Open the
 repository in a supporting editor to skip the local tool setup.
 
 ## Checks
 
-Two sensors gate a change, and you need both - `pre-commit` doesn't run the
-tests:
+Run both before submitting. `pre-commit` doesn't run the tests:
 
 ```bash
 pre-commit run --all-files   # formatting, lint, types, prose, links
@@ -175,10 +169,9 @@ Two how-to guides cover the module development loop:
 
 ## Code review process
 
-- The project team reviews PRs on a regular basis, typically within a week
-- Reviewers provide feedback through GitHub review comments
-- Maintainers may request changes before merging
-- Once approved, maintainers will merge your PR
+Woodland Generators has one maintainer, so expect a review within about a week.
+Feedback arrives as GitHub review comments and may ask for changes. The
+maintainer merges the PR once it's approved.
 
 [bug-template]:
   https://github.com/alunduil/woodland-generators/issues/new?template=bug-report.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,8 @@ Start with an issue labeled [good first issue][good-first-issue] or [help
 wanted][help-wanted]. Both filters list work that's ready to pick up without
 deep context on the codebase.
 
-Typos and formatting fixes need no issue at all - open a pull request directly.
+Typos and formatting fixes need no issue at all - see
+[small fixes](#for-small-fixes-typos-formatting).
 
 ## Project layout
 
@@ -93,12 +94,8 @@ pre-commit run --all-files   # formatting, lint, types, prose, links
 pnpm test                    # Jest suite
 ```
 
-`pre-commit run --all-files` covers Prettier, ESLint, `tsc --noEmit`, `knip`,
-`markdownlint`, `yamllint`, `actionlint`, `shellcheck`, REUSE licensing, Vale
-prose, and a link check. Many of those hooks fix files in place, so re-stage
-anything they touch.
-
-The authoritative hook list lives in `.pre-commit-config.yaml`.
+Many hooks fix files in place, so re-stage anything they touch. The full hook
+list lives in `.pre-commit-config.yaml`.
 
 ## Tests
 


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` called the project a CLI tool and sent contributors to
`pnpm run cli` and a root `build:watch`, neither of which exists — Quick start
failed at two consecutive steps, and both issue-template links landed on a blank
picker. Rewritten against the nayafia template for the pnpm workspace as it is
now, then trimmed for duplication and filler.

What's new: a Checks section, since `pre-commit` doesn't run the tests and the
file named only one of the two sensors; Your first contribution; Project layout;
and pointers to the ADR process and the Foundry dev loop from #226.

## Gotchas

- **CI will not run on this PR.** The workflows trigger on `master` while the
  default branch is `main` (#369) — the last 15 runs on this repo are all
  `PR Title`. Verification below is local by necessity.
- **Releases stay undocumented, against #240's acceptance criteria.** No release
  tooling is wired up, both packages sit at `0.0.0`, and nothing publishes, so
  that criterion is recorded as deferred rather than answered with filler.
- The `eslint` hook fails. Pre-existing and unrelated (#441) — it reproduces
  identically on a stashed tree and touches no file in this diff.
- Audit finds outside this file were already tracked: #357, #441, #369. Three
  weren't, and are now filed: #451, #454, #455.

## Verification

- `pre-commit run --all-files` is clean apart from that `eslint` failure.
- Every command the file names was checked against the manifests. `build:watch`
  is absent at the root and present on `@woodland-generators/core`.
- `lychee` does not validate fragments — `lychee.toml` sets no fragment option —
  so its pass said nothing about the new `#for-small-fixes-typos-formatting`
  link. markdownlint's MD051 does, and a negative test confirmed that rule fires
  rather than sits quiet.

Closes #240
Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwrVPdVgvNuisr2QryfFkE
